### PR TITLE
v1.0.6 many bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *.pyc
 .idea/
+.eggs/
 build/
 dist/
 mf2py.egg-info/

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -1,14 +1,45 @@
 import sys
 import bs4
+import copy
 
 if sys.version < '3':
+    from urlparse import urljoin
     text_type = unicode
     binary_type = str
 else:
+    from urllib.parse import urljoin
     text_type = str
     binary_type = bytes
-    basestring = str
 
+def get_textContent(el, replace_img=False, base_url=''):
+    """ Get the text content of an element, replacing images by alt or src
+    """
+
+    # copy el to avoid making direct changes
+    el_copy = copy.deepcopy(el)
+
+    # drop all <style> and <script> elements
+    drops = el_copy.find_all(['style', 'script'])
+    for drop in drops:
+        drop.decompose()
+
+    # replace <img> with alt or src
+    if replace_img:
+        imgs = el_copy.find_all('img')
+
+        for img in imgs:
+            replacement = img.get('alt')
+            if replacement is None:
+                replacement = img.get('src')
+                if replacement is not None:
+                    replacement = ' ' + urljoin(base_url, replacement) + ' '
+
+            if replacement is None:
+                replacement = ''
+
+            img.replace_with(replacement)
+
+    return el_copy.get_text().strip()
 
 def get_attr(el, attr, check_name=None):
     """Get the attribute of an element if it exists and is not empty.

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -10,6 +10,7 @@ else:
     from urllib.parse import urljoin
     text_type = str
     binary_type = bytes
+    basestring = str
 
 def get_textContent(el, replace_img=False, base_url=''):
     """ Get the text content of an element, replacing images by alt or src

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -16,7 +16,7 @@ def get_textContent(el, replace_img=False, base_url=''):
     """
 
     # copy el to avoid making direct changes
-    el_copy = copy.deepcopy(el)
+    el_copy = copy.copy(el)
 
     # drop all <style> and <script> elements
     drops = el_copy.find_all(['style', 'script'])

--- a/mf2py/implied_properties.py
+++ b/mf2py/implied_properties.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, print_function
 from . import mf2_classes
-from .dom_helpers import get_attr, get_children
+from .dom_helpers import get_attr, get_children, get_textContent
 import sys
 
 if sys.version < '3':
@@ -9,7 +9,7 @@ else:
     from urllib.parse import urljoin
 
 
-def name(el):
+def name(el, base_url=''):
     """Find an implied name property
 
     Args:
@@ -60,7 +60,7 @@ def name(el):
                 return [prop_value]
 
     # use text if all else fails
-    return [el.get_text().strip()]
+    return [get_textContent(el, replace_img=True, base_url=base_url)]
 
 
 def photo(el, base_url=''):

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -195,6 +195,6 @@ def datetime(el, default_date=None):
 def embedded(el, base_url=''):
     """Process e-* properties"""
     return {
-        'html': el.decode_contents(),    # secret bs4 method to get innerHTML
+        'html': el.decode_contents().strip(),    # secret bs4 method to get innerHTML
         'value': get_textContent(el, replace_img=True, base_url=base_url)
     }

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -39,40 +39,31 @@ def get_vcp_children(el):
 
 def text(el):
     """Process p-* properties"""
+
     # handle value-class-pattern
     value_els = get_vcp_children(el)
     if value_els:
         return ''.join(get_vcp_value(el) for el in value_els)
 
-    prop_value = get_attr(el, "title", check_name="abbr")
-    if prop_value is not None:
-        return prop_value
+    prop_value = get_attr(el, "title", check_name=("abbr", "link"))\
+        or get_attr(el, "value", check_name=("data", "input"))\
+        or get_attr(el, "alt", check_name=("img", "area"))\
+        or el.get_text()
 
-    prop_value = get_attr(el, "value", check_name=("data", "input"))
-    if prop_value is not None:
-        return prop_value
-
-    prop_value = get_attr(el, "alt", check_name=("img", "area"))
-    if prop_value is not None:
-        return prop_value
-
-    # see if get_text() replaces img with alts
-    # strip here?
-    return el.get_text()
+    # drop <script> and <style>
+    # replace nested <img> with alt or src
+    # strip here
+    return prop_value
 
 
 def url(el, base_url=''):
     """Process u-* properties"""
-    prop_value = get_attr(el, "href", check_name=("a", "area", "link"))
-    if prop_value is not None:
-        return urljoin(base_url, prop_value)  # make urls absolute
 
-    prop_value = get_attr(el, "src", check_name=("img", "audio", "video",
-                                                 "source"))
-    if prop_value is not None:
-        return urljoin(base_url, prop_value)
+    prop_value = get_attr(el, "href", check_name=("a", "area", "link"))\
+        or get_attr(el, "src", check_name=("img", "audio", "video", "source"))\
+        or get_attr(el, "poster", check_name="video")\
+        or get_attr(el, "data", check_name="object")
 
-    prop_value = get_attr(el, "data", check_name="object")
     if prop_value is not None:
         return urljoin(base_url, prop_value)
 
@@ -81,16 +72,13 @@ def url(el, base_url=''):
         return urljoin(base_url, ''.join(get_vcp_value(el)
                        for el in value_els))
 
-    prop_value = get_attr(el, "title", check_name="abbr")
-    if prop_value is not None:
-        return prop_value
+    prop_value = get_attr(el, "title", check_name="abbr")\
+        or get_attr(el, "value", check_name=("data", "input"))\
+        or el.get_text()
 
-    prop_value = get_attr(el, "value", check_name=("data", "input"))
-    if prop_value is not None:
-        return prop_value
-
+    # drop <script> and <style>
     # strip here?
-    return el.get_text()
+    return prop_value
 
 
 def datetime(el, default_date=None):

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -1,7 +1,7 @@
 """functions to parse the properties of elements"""
 from __future__ import unicode_literals, print_function
 
-from .dom_helpers import get_attr, get_children
+from .dom_helpers import get_attr, get_children, get_textContent
 import sys
 import re
 
@@ -37,7 +37,7 @@ def get_vcp_children(el):
             and ('value' in c['class'] or 'value-title' in c['class'])]
 
 
-def text(el):
+def text(el, base_url=''):
     """Process p-* properties"""
 
     # handle value-class-pattern
@@ -48,11 +48,8 @@ def text(el):
     prop_value = get_attr(el, "title", check_name=("abbr", "link"))\
         or get_attr(el, "value", check_name=("data", "input"))\
         or get_attr(el, "alt", check_name=("img", "area"))\
-        or el.get_text()
+        or get_textContent(el, replace_img=True, base_url=base_url)
 
-    # drop <script> and <style>
-    # replace nested <img> with alt or src
-    # strip here
     return prop_value
 
 
@@ -74,10 +71,8 @@ def url(el, base_url=''):
 
     prop_value = get_attr(el, "title", check_name="abbr")\
         or get_attr(el, "value", check_name=("data", "input"))\
-        or el.get_text()
+        or get_textContent(el)
 
-    # drop <script> and <style>
-    # strip here?
     return prop_value
 
 
@@ -172,7 +167,7 @@ def datetime(el, default_date=None):
     prop_value = get_attr(el, "datetime", check_name=("time", "ins", "del"))\
         or get_attr(el, "title", check_name="abbr")\
         or get_attr(el, "value", check_name=("data", "input"))\
-        or el.get_text()  # strip here?
+        or get_textContent(el) 
 
     # if this is just a time, augment with default date
     match = re.match(TIME_RE + '$', prop_value)
@@ -186,9 +181,9 @@ def datetime(el, default_date=None):
             match and match.group('date'),)
 
 
-def embedded(el):
+def embedded(el, base_url=''):
     """Process e-* properties"""
     return {
         'html': el.decode_contents(),    # secret bs4 method to get innerHTML
-        'value': el.get_text()     # strip here?
+        'value': get_textContent(el, replace_img=True, base_url=base_url)
     }

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -45,10 +45,13 @@ def text(el, base_url=''):
     if value_els:
         return ''.join(get_vcp_value(el) for el in value_els)
 
-    prop_value = get_attr(el, "title", check_name=("abbr", "link"))\
-        or get_attr(el, "value", check_name=("data", "input"))\
-        or get_attr(el, "alt", check_name=("img", "area"))\
-        or get_textContent(el, replace_img=True, base_url=base_url)
+    prop_value = get_attr(el, "title", check_name=("abbr", "link"))
+    if prop_value is None:
+        prop_value = get_attr(el, "value", check_name=("data", "input"))
+    if prop_value is None:
+        prop_value = get_attr(el, "alt", check_name=("img", "area"))
+    if prop_value is None:
+        prop_value = get_textContent(el, replace_img=True, base_url=base_url)
 
     return prop_value
 
@@ -56,10 +59,13 @@ def text(el, base_url=''):
 def url(el, base_url=''):
     """Process u-* properties"""
 
-    prop_value = get_attr(el, "href", check_name=("a", "area", "link"))\
-        or get_attr(el, "src", check_name=("img", "audio", "video", "source"))\
-        or get_attr(el, "poster", check_name="video")\
-        or get_attr(el, "data", check_name="object")
+    prop_value = get_attr(el, "href", check_name=("a", "area", "link"))
+    if prop_value is None:
+        props_value = get_attr(el, "src", check_name=("img", "audio", "video", "source"))
+    if prop_value is None:
+        prop_value = get_attr(el, "poster", check_name="video")
+    if prop_value is None:
+        prop_value = get_attr(el, "data", check_name="object")
 
     if prop_value is not None:
         return urljoin(base_url, prop_value)
@@ -69,9 +75,11 @@ def url(el, base_url=''):
         return urljoin(base_url, ''.join(get_vcp_value(el)
                        for el in value_els))
 
-    prop_value = get_attr(el, "title", check_name="abbr")\
-        or get_attr(el, "value", check_name=("data", "input"))\
-        or get_textContent(el)
+    prop_value = get_attr(el, "title", check_name="abbr")
+    if prop_value is None:
+        prop_value = get_attr(el, "value", check_name=("data", "input"))
+    if prop_value is None:
+        prop_value = get_textContent(el)
 
     return prop_value
 
@@ -164,10 +172,13 @@ def datetime(el, default_date=None):
 
         return try_normalize(date_time_value), date_part
 
-    prop_value = get_attr(el, "datetime", check_name=("time", "ins", "del"))\
-        or get_attr(el, "title", check_name="abbr")\
-        or get_attr(el, "value", check_name=("data", "input"))\
-        or get_textContent(el) 
+    prop_value = get_attr(el, "datetime", check_name=("time", "ins", "del"))
+    if prop_value is None:
+        prop_value = get_attr(el, "title", check_name="abbr")
+    if prop_value is None:
+        prop_value = get_attr(el, "value", check_name=("data", "input"))
+    if prop_value is None:
+        prop_value = get_textContent(el) 
 
     # if this is just a time, augment with default date
     match = re.match(TIME_RE + '$', prop_value)

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -61,7 +61,7 @@ def url(el, base_url=''):
 
     prop_value = get_attr(el, "href", check_name=("a", "area", "link"))
     if prop_value is None:
-        props_value = get_attr(el, "src", check_name=("img", "audio", "video", "source"))
+        prop_value = get_attr(el, "src", check_name=("img", "audio", "video", "source"))
     if prop_value is None:
         prop_value = get_attr(el, "poster", check_name="video")
     if prop_value is None:

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -75,7 +75,7 @@ class Parser(object):
         if url is not None:
             self.__url__ = url
 
-            if self.__doc__ is None:
+            if doc is None:
                 data = requests.get(self.__url__, headers={
                     'User-Agent': self.useragent,
                 })

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals, print_function
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, FeatureNotFound
 from bs4.element import Tag
 from mf2py import backcompat, mf2_classes, implied_properties, parse_property
 from mf2py import temp_fixes
@@ -63,7 +63,7 @@ class Parser(object):
 
     dict_class = dict
 
-    def __init__(self, doc=None, url=None, html_parser=None):
+    def __init__(self, doc=None, url=None, html_parser='html5lib'):
         self.__url__ = None
         self.__doc__ = None
         self.__parsed__ = self.dict_class([
@@ -71,13 +71,6 @@ class Parser(object):
             ('rels', self.dict_class()),
             ('rel-urls', self.dict_class()),
         ])
-
-        if doc is not None:
-            self.__doc__ = doc
-            if isinstance(doc, BeautifulSoup) or isinstance(doc, Tag):
-                self.__doc__ = doc
-            else:
-                self.__doc__ = BeautifulSoup(doc, features=html_parser)
 
         if url is not None:
             self.__url__ = url
@@ -87,13 +80,28 @@ class Parser(object):
                     'User-Agent': self.useragent,
                 })
 
-                # check for charater encodings and use 'correct' data
+                # update to final URL after redirects
+                self.__url__ = data.url
+
+                # HACK: check for character encodings and use 'correct' data
                 if 'charset' in data.headers.get('content-type', ''):
-                    self.__doc__ = BeautifulSoup(data.text,
-                                                 features=html_parser)
+                    doc = data.text
                 else:
-                    self.__doc__ = BeautifulSoup(data.content,
-                                                 features=html_parser)
+                    doc = data.content
+
+        if doc is not None:
+            self.__doc__ = doc
+            if isinstance(doc, BeautifulSoup) or isinstance(doc, Tag):
+                self.__doc__ = doc
+            else:
+                try:
+                    # try the user-given html parser or default html5lib
+                    self.__doc__ = BeautifulSoup(doc, features=html_parser)
+                except FeatureNotFound:
+                    # maybe raise a warning?
+                    # else switch to default use
+                    self.__doc__ = BeautifulSoup(doc)
+
 
         # check for <base> tag
         if self.__doc__:
@@ -134,15 +142,18 @@ class Parser(object):
             properties = self.dict_class()
             children = []
             self._default_date = None
+            # flag for processing implied name
+            do_implied_name = True
 
             # parse for properties and children
             for child in get_children(el):
-                child_props, child_children = parse_props(child)
+                child_props, child_children, child_stops_implied_name = parse_props(child)
                 for key, new_value in child_props.items():
                     prop_value = properties.get(key, [])
                     prop_value.extend(new_value)
                     properties[key] = prop_value
                 children.extend(child_children)
+                do_implied_name = do_implied_name and not child_stops_implied_name
 
             # complex h-* objects can take their "value" from the
             # first explicit property ("name" for p-* or "url" for u-*)
@@ -150,7 +161,9 @@ class Parser(object):
                 simple_value = properties[value_property][0]
 
             # if some properties not already found find in implied ways
-            if "name" not in properties:
+
+            # stop implied name if any p-*, e-*, h-* is already found
+            if "name" not in properties and do_implied_name:
                 properties["name"] = [text_type(prop)
                                       for prop
                                       in implied_properties.name(el)]
@@ -201,6 +214,8 @@ class Parser(object):
             """
             props = self.dict_class()
             children = []
+            # Does this element stop implied name?
+            stops_implied_name = False
 
             classes = el.get("class", [])
             # Is this element a microformat root?
@@ -212,13 +227,16 @@ class Parser(object):
             p_value = None
             for prop_name in mf2_classes.text(classes):
                 is_property_el = True
+                stops_implied_name = True
                 prop_value = props.setdefault(prop_name, [])
 
                 # if value has not been parsed then parse it
                 if p_value is None:
                     p_value = text_type(parse_property.text(el).strip())
 
+
                 if root_class_names:
+                    stops_implied_name = True
                     prop_value.append(handle_microformat(
                         root_class_names, el, value_property="name",
                         simple_value=p_value))
@@ -236,6 +254,7 @@ class Parser(object):
                     u_value = parse_property.url(el, base_url=self.__url__)
 
                 if root_class_names:
+                    stops_implied_name = True
                     prop_value.append(handle_microformat(
                         root_class_names, el, value_property="url",
                         simple_value=u_value))
@@ -257,6 +276,7 @@ class Parser(object):
                         self._default_date = new_date
 
                 if root_class_names:
+                    stops_implied_name = True
                     prop_value.append(handle_microformat(
                         root_class_names, el,
                         simple_value=text_type(dt_value)))
@@ -268,6 +288,7 @@ class Parser(object):
             e_value = None
             for prop_name in mf2_classes.embedded(classes):
                 is_property_el = True
+                stops_implied_name = True
                 prop_value = props.setdefault(prop_name, [])
 
                 # if value has not been parsed then parse it
@@ -275,6 +296,7 @@ class Parser(object):
                     e_value = parse_property.embedded(el)
 
                 if root_class_names:
+                    stops_implied_name = True
                     prop_value.append(handle_microformat(
                         root_class_names, el, simple_value=e_value))
                 else:
@@ -283,19 +305,21 @@ class Parser(object):
             # if this is not a property element, but it is a h-* microformat,
             # add it to our list of children
             if not is_property_el and root_class_names:
+                stops_implied_name = True
                 children.append(handle_microformat(root_class_names, el))
 
             # parse child tags, provided this isn't a microformat root-class
             if not root_class_names:
                 for child in get_children(el):
-                    child_properties, child_microformats = parse_props(child)
+                    child_properties, child_microformats, child_stops_implied_name = parse_props(child)
                     for prop_name in child_properties:
                         v = props.get(prop_name, [])
                         v.extend(child_properties[prop_name])
                         props[prop_name] = v
                     children.extend(child_microformats)
+                    stops_implied_name = stops_implied_name or child_stops_implied_name
 
-            return props, children
+            return props, children, stops_implied_name
 
         def parse_rels(el):
             """Parse an element for rel microformats

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -162,7 +162,7 @@ class Parser(object):
             if "name" not in properties:
                 properties["name"] = [text_type(prop)
                                       for prop
-                                      in implied_properties.name(el)]
+                                      in implied_properties.name(el, base_url=self.__url__)]
             if "photo" not in properties:
                 x = implied_properties.photo(el, base_url=self.__url__)
                 if x is not None:
@@ -225,7 +225,7 @@ class Parser(object):
 
                 # if value has not been parsed then parse it
                 if p_value is None:
-                    p_value = text_type(parse_property.text(el).strip())
+                    p_value = text_type(parse_property.text(el, base_url=self.__url__))
 
 
                 if root_class_names:
@@ -282,7 +282,7 @@ class Parser(object):
 
                 # if value has not been parsed then parse it
                 if e_value is None:
-                    e_value = parse_property.embedded(el)
+                    e_value = parse_property.embedded(el, base_url=self.__url__)
 
                 if root_class_names:
                     prop_value.append(handle_microformat(

--- a/mf2py/version.py
+++ b/mf2py/version.py
@@ -1,4 +1,4 @@
 # Define the version number. This class is exec'd by setup.py to read
 # the value without loading mf2py (loading mf2py is bad if its dependencies
 # haven't been installed yet, which is common during setup)
-__version__ = '1.0.5'
+__version__ = '1.0.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-html5lib==0.999
+html5lib==1.0.1
 nose==1.3.0
 mock==1.3.0
-requests==2.0.1
-BeautifulSoup4==4.3.2
+requests==2.18.4
+BeautifulSoup4==4.6.0
 Flask==0.10.1
 gunicorn==19.1.1
 -e .

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -228,7 +228,7 @@ def test_embedded_parsing():
         '   <p>Blah.</p>\n   <p>Blah blah blah.</p>\n  ')
     assert_equal(
         result["items"][0]["properties"]["content"][0]["value"],
-        '\n   Blah blah blah blah blah.\n   Blah.\n   Blah blah blah.\n  ')
+        'Blah blah blah blah blah.\n   Blah.\n   Blah blah blah.')
 
 
 def test_backcompat():

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -224,8 +224,8 @@ def test_embedded_parsing():
     result = parse_fixture("embedded.html")
     assert_equal(
         result["items"][0]["properties"]["content"][0]["html"],
-        '\n   <p>Blah blah blah blah blah.</p>\n' +
-        '   <p>Blah.</p>\n   <p>Blah blah blah.</p>\n  ')
+        '<p>Blah blah blah blah blah.</p>\n' +
+        '   <p>Blah.</p>\n   <p>Blah blah blah.</p>')
     assert_equal(
         result["items"][0]["properties"]["content"][0]["value"],
         'Blah blah blah blah blah.\n   Blah.\n   Blah blah blah.')


### PR DESCRIPTION
version 1.0.6

many bug fixes for parsing according to spec

Summary
1) strip leading/trailing white space for `e-*[html]`. update the corresponding tests
2) blank values explicitly authored are allowed as property values 
3) include `alt` or `src` from `<img>` in parsing for `p-*` and `e-*[value]`
4) parse `title` from `<link>` for `p-*` resolves #84 
5) and `poster` from `<video>` for `u-*` resolves #76 
6) use `html5lib` as default parser
7) use the final redirect URL resolves #62 
8) update requirements to use BS4 v4.6.0 and html5lib v1.0.1