### PR TITLE
imporoved vcp parsing for datetimes

### DIFF
--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -153,8 +153,8 @@ def datetime(el, default_date=None):
                 if val:
                     date_parts.append(val.strip())
 
-        date_part = default_date
-        time_part = None
+        date_part = time_part = tz_part = None
+
         for part in date_parts:
             match = re.match(DATETIME_RE + '$', part)
             if match:
@@ -163,16 +163,26 @@ def datetime(el, default_date=None):
                 time_part = match.group('time')
                 return try_normalize(part, match=match), date_part
 
-            if re.match(TIME_RE + '$', part):
+            # only use first found value
+            if re.match(TIME_RE + '$', part) and time_part is None:
                 time_part = part
-            elif re.match(DATE_RE + '$', part):
+            elif re.match(DATE_RE + '$', part) and date_part is None:
                 date_part = part
+            elif re.match(TIMEZONE_RE + '$', part) and tz_part is None:
+                tz_part = part
+
+        # use default date
+        if date_part is None:
+            date_part = default_date
 
         if date_part and time_part:
             date_time_value = '%s %s' % (date_part,
                                          time_part)
         else:
             date_time_value = date_part or time_part
+
+        if tz_part:
+            date_time_value += tz_part
 
         return try_normalize(date_time_value), date_part
 

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -165,7 +165,7 @@ def datetime(el, default_date=None):
                 date_part = part
 
         if date_part and time_part:
-            date_time_value = '%sT%s' % (date_part,
+            date_time_value = '%s %s' % (date_part,
                                          time_part)
         else:
             date_time_value = date_part or time_part
@@ -183,7 +183,7 @@ def datetime(el, default_date=None):
     # if this is just a time, augment with default date
     match = re.match(TIME_RE + '$', prop_value)
     if match and default_date:
-        prop_value = '%sT%s' % (default_date, prop_value)
+        prop_value = '%s %s' % (default_date, prop_value)
         return try_normalize(prop_value), default_date
 
     # otherwise, treat it as a full date

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -105,15 +105,19 @@ def datetime(el, default_date=None):
             datestr = match.group('date')
             hourstr = match.group('hour')
             minutestr = match.group('minute') or '00'
-            secondstr = match.group('second') or '00'
+            secondstr = match.group('second')
             ampmstr = match.group('ampm')
             separator = match.group('separator')
             if ampmstr:
                 hourstr = match.group('hour')
                 if ampmstr.startswith('p'):
                     hourstr = str(int(hourstr) + 12)
-            dtstr = '%s%s%s:%s:%s' % (
-                datestr, separator, hourstr, minutestr, secondstr)
+            dtstr = '%s%s%s:%s' % (
+                datestr, separator, hourstr, minutestr)
+
+            if secondstr:
+                dtstr += ':'+secondstr
+
             tzstr = match.group('tz')
             if tzstr:
                 dtstr += tzstr

--- a/test/examples/datetimes.html
+++ b/test/examples/datetimes.html
@@ -76,5 +76,19 @@
 
  </div>
 
+ <div class="h-event">
+   <h1 class="p-name">Implied Date w/ separate Timezone</h1>
+
+   <p> When:
+     <span class="dt-start">
+       <span class="value" title="June 1, 2014">2014-06-01</span>
+       <span class="value" title="12:30">12:30</span>
+       (UTC<span class="value">-06:00</span>)
+       –
+       <span class="dt-end">19:30</span>
+   </p>
+
+ </div>
+
 </body>
 </html>

--- a/test/examples/datetimes.html
+++ b/test/examples/datetimes.html
@@ -90,5 +90,22 @@
 
  </div>
 
+ <div class="h-event">
+   <h1 class="p-name">Multiple date and time values</h1>
+
+   <p> When:
+     <span class="dt-start">
+       <span class="value" title="June 1, 2014">2014-06-01</span>
+       <span class="value" title="June 1, 3014">3014-06-01</span>
+       <span class="value" title="12:30">12:30</span>
+       (UTC<span class="value">-06:00</span>)
+       <span class="value" title="23:00">23:00</span>
+       (UTC<span class="value">+01:00</span>)
+       –
+       <span class="dt-end">19:30</span>
+   </p>
+
+ </div>
+
 </body>
 </html>

--- a/test/examples/implied_relative_datetimes.html
+++ b/test/examples/implied_relative_datetimes.html
@@ -12,7 +12,7 @@
     </article>
     <p>
       Explanation: this is to test for the behaviour described
-      <a href="http://microformats.org/wiki/value-class-pattern#microformats2_parsers">here</a>.
+      <a href="http://microformats.org/wiki/value-class-pattern#microformats2_parsers_implied_date">here</a>.
     </p>
   </body>
 </html>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -188,15 +188,15 @@ def test_datetime_parsing():
 def test_datetime_vcp_parsing():
     result = parse_fixture("datetimes.html")
     assert_equal(result["items"][1]["properties"]["published"][0],
-                 "3014-01-01T01:21:00Z")
+                 "3014-01-01 01:21:00Z")
     assert_equal(result["items"][2]["properties"]["updated"][0],
                  "2014-03-11 09:55:00")
     assert_equal(result["items"][3]["properties"]["published"][0],
-                 "2014-01-30T15:28:00")
+                 "2014-01-30 15:28:00")
     assert_equal(result["items"][4]["properties"]["published"][0],
                  "9999-01-14T11:52:00+08:00")
     assert_equal(result["items"][5]["properties"]["published"][0],
-                 "2014-06-01T12:30:00-06:00")
+                 "2014-06-01 12:30:00-06:00")
 
 
 def test_dt_end_implied_date():
@@ -207,15 +207,15 @@ def test_dt_end_implied_date():
 
     event_wo_tz = result["items"][6]
     assert_equal(event_wo_tz["properties"]["start"][0],
-                 "2014-05-21T18:30:00")
+                 "2014-05-21 18:30:00")
     assert_equal(event_wo_tz["properties"]["end"][0],
-                 "2014-05-21T19:30:00")
+                 "2014-05-21 19:30:00")
 
     event_w_tz = result["items"][7]
     assert_equal(event_w_tz["properties"]["start"][0],
-                 "2014-06-01T12:30:00-06:00")
+                 "2014-06-01 12:30:00-06:00")
     assert_equal(event_w_tz["properties"]["end"][0],
-                 "2014-06-01T19:30:00-06:00")
+                 "2014-06-01 19:30:00-06:00")
 
 
 def test_embedded_parsing():
@@ -559,8 +559,8 @@ def test_implied_properties_silo_pub():
 
 def test_relative_datetime():
     result = parse_fixture("implied_relative_datetimes.html")
-    assert_equal('2015-01-02T05:06:00',
-                 result[u'items'][0][u'properties'][u'updated'][0])
+    assert_equal(result[u'items'][0][u'properties'][u'updated'][0],
+                 '2015-01-02 05:06:00')
 
 def test_stop_implied_name_nested_h():
     result = parse_fixture("stop_implied_name_nested_h.html")

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -197,6 +197,10 @@ def test_datetime_vcp_parsing():
                  "9999-01-14T11:52+08:00")
     assert_equal(result["items"][5]["properties"]["published"][0],
                  "2014-06-01 12:30-06:00")
+    assert_equal(result["items"][8]["properties"]["start"][0],
+                 "2014-06-01 12:30-06:00")
+    assert_equal(result["items"][9]["properties"]["start"][0],
+                 "2014-06-01 12:30-06:00")
 
 
 def test_dt_end_implied_date():
@@ -216,6 +220,7 @@ def test_dt_end_implied_date():
                  "2014-06-01 12:30-06:00")
     assert_equal(event_w_tz["properties"]["end"][0],
                  "2014-06-01 19:30-06:00")
+
 
 
 def test_embedded_parsing():

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -188,15 +188,15 @@ def test_datetime_parsing():
 def test_datetime_vcp_parsing():
     result = parse_fixture("datetimes.html")
     assert_equal(result["items"][1]["properties"]["published"][0],
-                 "3014-01-01 01:21:00Z")
+                 "3014-01-01 01:21Z")
     assert_equal(result["items"][2]["properties"]["updated"][0],
-                 "2014-03-11 09:55:00")
+                 "2014-03-11 09:55")
     assert_equal(result["items"][3]["properties"]["published"][0],
-                 "2014-01-30 15:28:00")
+                 "2014-01-30 15:28")
     assert_equal(result["items"][4]["properties"]["published"][0],
-                 "9999-01-14T11:52:00+08:00")
+                 "9999-01-14T11:52+08:00")
     assert_equal(result["items"][5]["properties"]["published"][0],
-                 "2014-06-01 12:30:00-06:00")
+                 "2014-06-01 12:30-06:00")
 
 
 def test_dt_end_implied_date():
@@ -207,15 +207,15 @@ def test_dt_end_implied_date():
 
     event_wo_tz = result["items"][6]
     assert_equal(event_wo_tz["properties"]["start"][0],
-                 "2014-05-21 18:30:00")
+                 "2014-05-21 18:30")
     assert_equal(event_wo_tz["properties"]["end"][0],
-                 "2014-05-21 19:30:00")
+                 "2014-05-21 19:30")
 
     event_w_tz = result["items"][7]
     assert_equal(event_w_tz["properties"]["start"][0],
-                 "2014-06-01 12:30:00-06:00")
+                 "2014-06-01 12:30-06:00")
     assert_equal(event_w_tz["properties"]["end"][0],
-                 "2014-06-01 19:30:00-06:00")
+                 "2014-06-01 19:30-06:00")
 
 
 def test_embedded_parsing():
@@ -560,7 +560,7 @@ def test_implied_properties_silo_pub():
 def test_relative_datetime():
     result = parse_fixture("implied_relative_datetimes.html")
     assert_equal(result[u'items'][0][u'properties'][u'updated'][0],
-                 '2015-01-02 05:06:00')
+                 '2015-01-02 05:06')
 
 def test_stop_implied_name_nested_h():
     result = parse_fixture("stop_implied_name_nested_h.html")


### PR DESCRIPTION
Changes
1. use space separator doe times instead of "T"
2. Don't add "00" seconds unless authored
3. use TZ authored in separate `value` element
4. only use first found `value` of a particular type `date`, `time`, or `timezone`. 