### PR TITLE
new version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 1.1.1 - 2018-06-15
+
+- streamline backcompat to use JSON only.
+- fix multiple mf1 root rel-tag parsing 
+- correct url and photo for hreview.
+- add rules for nested hreview. update backcompat to use multiple matches in old properties.
+- fix `rel-tag` to `p-category` conversion so that other classes are not lost.
+- use original authored html for `e-*` parsing in backcompat
+- make classes and rels into unordered (alphabetically ordered) deduped arrays.
+- only use class names for mf2 which follow the naming rules
+- fix `parse` method to use default html parser.
+- always use the first value for attributes for rels.
+- correct AM/PM conversion in datetime value class pattern.
+ - add ordinal date parsing to datetimes value class pattern. ordinal date is normalised to YYYY-MM-DD
+- remove hack for html tag classes since that is fixed in new BS
+- better whitespace algorithm for `name` and `html.value` parsing
+- experimental flag for including `alt` in `u-photo` parsing
+- make a copy of the BeautifulSoup given by user to work on for parsing to prevent changes to original doc
+- bump version to 1.1.1 
+
 ## 1.1.0 - 2018-03-16
 
 - bump version to 1.1.0 since it is a "major" change 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Filter by microformat type
 
     p.to_dict(filter_by_type="h-entry")
     p.to_json(filter_by_type="h-entry")
+    
+Experimental features
+---------------------
+- pass the optional argument `img_with_alt=True` to either the `Parser` object or to the `parse` method to enable parsing of the `alt` attribute of `<img>` tags according to [issue: image alt text is lost during parsing](https://github.com/microformats/microformats2-parsing/issues/2). By default this is `False` to be backwards compatible.
 
 Frontends
 -------------
@@ -68,3 +72,4 @@ Contributions
 We welcome contributions and bug reports via Github, and on the microformats wiki.
 
 We try to follow the [IndieWebCamp code of conduct](http://indiewebcamp.com/code-of-conduct). Please be respectful of other contributors, and forge a spirit of positive co-operation without discrimination or disrespect.
+

--- a/mf2py/backcompat-rules/hentry.json
+++ b/mf2py/backcompat-rules/hentry.json
@@ -35,5 +35,13 @@
         "longitude": [
             "p-longitude"
         ]
+    },
+    "rels": {
+        "bookmark": [
+            "u-url"
+        ],
+        "tag": [
+            "p-category"
+        ]
     }
 }

--- a/mf2py/backcompat-rules/hfeed.json
+++ b/mf2py/backcompat-rules/hfeed.json
@@ -18,5 +18,10 @@
         "title": [
             "p-name"
         ]
+    },
+    "rels": {
+        "tag": [
+            "p-category"
+        ]
     }
 }

--- a/mf2py/backcompat-rules/hproduct.json
+++ b/mf2py/backcompat-rules/hproduct.json
@@ -26,8 +26,7 @@
         ], 
         "review": [
             "p-review", 
-            "h-review", 
-            "e-description"
+            "h-review" 
         ], 
         "fn": [
             "p-name"

--- a/mf2py/backcompat-rules/hrecipe.json
+++ b/mf2py/backcompat-rules/hrecipe.json
@@ -30,6 +30,14 @@
         ], 
         "ingredient": [
             "p-ingredient"
+        ],
+        "category": [
+            "p-category"
+        ]
+    },
+    "rels": {
+        "tag": [
+            "p-category"
         ]
     }
 }

--- a/mf2py/backcompat-rules/hreview.json
+++ b/mf2py/backcompat-rules/hreview.json
@@ -17,9 +17,13 @@
             "h-card"
         ], 
         "url": [
+            "p-item", 
+            "h-item", 
             "u-url"
         ], 
         "photo": [
+            "p-item", 
+            "h-item", 
             "u-photo"
         ], 
         "best": [
@@ -35,6 +39,26 @@
         ], 
         "summary": [
             "p-name"
+        ],
+        "item vcard": [
+            "p-item",
+            "vcard"
+        ],
+        "item vevent": [
+            "p-item",
+            "vevent"
+        ],
+        "item hproduct": [
+            "p-item",
+            "hproduct"
+        ]
+    },
+    "rels": {
+        "self bookmark": [
+            "u-url"
+        ],
+        "tag": [
+            "p-category"
         ]
     }
 }

--- a/mf2py/backcompat-rules/vcard.json
+++ b/mf2py/backcompat-rules/vcard.json
@@ -97,6 +97,12 @@
         ], 
         "organization-name": [
             "p-organization-name"
+        ],
+        "title": [
+            "p-job-title"
+        ],
+        "role": [
+            "p-role"
         ]
     }
 }

--- a/mf2py/datetime_helpers.py
+++ b/mf2py/datetime_helpers.py
@@ -2,13 +2,14 @@
 from __future__ import unicode_literals, print_function
 
 import re
+from datetime import datetime
 
 # REGEX!
 
-DATE_RE = r'\d{4}-\d{2}-\d{2}'
+DATE_RE = r'(\d{4}-\d{2}-\d{2})|(\d{4}-\d{3})'
 SEC_RE = r'(:(?P<second>\d{2})(\.\d+)?)'
 RAWTIME_RE = r'(?P<hour>\d{1,2})(:(?P<minute>\d{2})%s?)?' % (SEC_RE)
-AMPM_RE = 'am|pm|a\.m\.|p\.m\.'
+AMPM_RE = r'am|pm|a\.m\.|p\.m\.|AM|PM|A\.M\.|P\.M\.'
 TIMEZONE_RE = r'Z|[+-]\d{2}:?\d{2}?'
 TIME_RE = (r'(?P<rawtime>%s)( ?(?P<ampm>%s))?( ?(?P<tz>%s))?' %
            (RAWTIME_RE, AMPM_RE, TIMEZONE_RE))
@@ -29,10 +30,26 @@ def normalize_datetime(dtstr, match=None):
             secondstr = match.group('second')
             ampmstr = match.group('ampm')
             separator = match.group('separator')
+
+            # convert ordinal date YYYY-DDD to YYYY-MM-DD
+            try:
+                datestr = datetime.strptime(datestr, '%Y-%j').strftime('%Y-%m-%d')
+            except ValueError:
+                # datestr was not in YYYY-DDD format
+                pass
+
+            # 12 to 24 time conversion
             if ampmstr:
                 hourstr = match.group('hour')
-                if ampmstr.startswith('p'):
-                    hourstr = str(int(hourstr) + 12)
+                hourint = int(hourstr)
+
+                if (ampmstr.startswith('a') or ampmstr.startswith('A')) and hourint == 12:
+                    hourstr = '00'
+
+                if (ampmstr.startswith('p') or ampmstr.startswith('P')) and hourint < 12:
+                    hourstr = str(hourint + 12)
+
+
             dtstr = '%s%s%s:%s' % (
                 datestr, separator, hourstr, minutestr)
 
@@ -43,4 +60,3 @@ def normalize_datetime(dtstr, match=None):
             if tzstr:
                 dtstr += tzstr
         return dtstr
-

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -69,7 +69,7 @@ def get_descendents(node):
         if isinstance(desc, bs4.Tag):
             yield desc
 
-def get_textContent(el, replace_img=False, base_url=''):
+def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
     """ Get the text content of an element, replacing images by alt or src
     """
 
@@ -78,7 +78,7 @@ def get_textContent(el, replace_img=False, base_url=''):
     P_BREAK_BEFORE = 1
     P_BREAK_AFTER = 0
 
-    def text_collection(el, replace_img=False, base_url=''):
+    def text_collection(el, replace_img=False, img_to_src=True, base_url=''):
         # returns array of strings or integers
 
         items = []
@@ -103,7 +103,7 @@ def get_textContent(el, replace_img=False, base_url=''):
 
         elif el.name == 'img' and replace_img:
             value = el.get('alt')
-            if value is None:
+            if value is None and img_to_src:
                 value = el.get('src')
                 if value is not None:
                     value = urljoin(base_url, value)
@@ -117,7 +117,7 @@ def get_textContent(el, replace_img=False, base_url=''):
         else:
             for child in el.children:
 
-                child_items = text_collection(child, replace_img, base_url)
+                child_items = text_collection(child, replace_img, img_to_src, base_url)
                 items.extend(child_items)
 
             if el.name == 'p':
@@ -127,7 +127,7 @@ def get_textContent(el, replace_img=False, base_url=''):
 
         return items
 
-    results = [t for t in text_collection(el, replace_img, base_url) if t is not '']
+    results = [t for t in text_collection(el, replace_img, img_to_src, base_url) if t is not '']
 
     if results:
         # remove <space> if it is first and last or if it is preceded by a <space> or <int> or followed by a <int>

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -1,6 +1,11 @@
+from __future__ import unicode_literals
+
 import sys
 import bs4
 import copy
+import re
+
+from bs4.element import Tag, NavigableString, Comment
 
 if sys.version < '3':
     from urlparse import urljoin
@@ -12,38 +17,8 @@ else:
     binary_type = bytes
     basestring = str
 
-def get_textContent(el, replace_img=False, base_url=''):
-    """ Get the text content of an element, replacing images by alt or src
-    """
-
-    # copy el to avoid making direct changes
-    el_copy = copy.copy(el)
-
-    # drop all <style> and <script> elements
-    drops = el_copy.find_all(['style', 'script'])
-    for drop in drops:
-        drop.decompose()
-
-    # replace <img> with alt or src
-    if replace_img:
-        imgs = el_copy.find_all('img')
-
-        for img in imgs:
-            replacement = img.get('alt')
-            if replacement is None:
-                replacement = img.get('src')
-                if replacement is not None:
-                    replacement = ' ' + urljoin(base_url, replacement) + ' '
-
-            if replacement is None:
-                replacement = ''
-
-            img.replace_with(replacement)
-
-    return el_copy.get_text().strip()
-
 def get_attr(el, attr, check_name=None):
-    """Get the attribute of an element if it exists and is not empty.
+    """Get the attribute of an element if it exists.
 
     Args:
       el (bs4.element.Tag): a DOM element
@@ -62,15 +37,136 @@ def get_attr(el, attr, check_name=None):
         return el.get(attr)
 
 
+def get_img_src_alt(img, dict_class, img_with_alt, base_url=''):
+    """given a img element, returns both src and alt attributes as a list of tuples if alt exists, else returns the src as a string
+    use for alt parsing with img
+    """
+
+    alt = get_attr(img, "alt", check_name="img")
+    src = get_attr(img, "src", check_name="img")
+
+    if src is not None:
+        src = urljoin(base_url, src)
+
+        if alt is None or not img_with_alt:
+            return text_type(src)
+        else:
+            return dict_class([
+                                ("value", text_type(src)),
+                                ("alt", text_type(alt))
+                            ])
+
 def get_children(node):
     """An iterator over the immediate children tags of this tag"""
-    for child in node.contents:
+    for child in node.children:
         if isinstance(child, bs4.Tag):
             yield child
 
 
 def get_descendents(node):
-    for child in get_children(node):
-        yield child
-        for desc in get_descendents(child):
+    """An iterator over the all children tags (descendants) of this tag"""
+    for desc in node.descendants:
+        if isinstance(desc, bs4.Tag):
             yield desc
+
+def get_textContent(el, replace_img=False, base_url=''):
+    """ Get the text content of an element, replacing images by alt or src
+    """
+
+    DROP_TAGS = ('script', 'style')
+    PRE_TAGS = ('pre',)
+    P_BREAK_BEFORE = 1
+    P_BREAK_AFTER = 0
+
+    def text_collection(el, replace_img=False, base_url=''):
+        # returns array of strings or integers
+
+        items = []
+
+        # drops the tags defined above and comments
+        if el.name in DROP_TAGS or isinstance(el, Comment):
+            items = []
+
+        elif isinstance(el, NavigableString):
+            value = text_type(el)
+            # replace \t \n \r by space
+            value = re.sub(r'\t|\n|\r', ' ', value)
+            # replace multiple spaces with one space
+            value = re.sub(r'[ ]{1,}', ' ', value)
+
+            value = value.strip() or value
+            items = [value]
+
+        # don't do anything special for PRE-formatted tags defined above
+        elif el.name in PRE_TAGS:
+            items = [el.get_text()]
+
+        elif el.name == 'img' and replace_img:
+            value = el.get('alt')
+            if value is None:
+                value = el.get('src')
+                if value is not None:
+                    value = urljoin(base_url, value)
+
+            if value is not None:
+                items = [' ', text_type(value), ' ']
+
+        elif el.name == 'br':
+            items = ['\n']
+
+        else:
+            for child in el.children:
+
+                child_items = text_collection(child, replace_img, base_url)
+                items.extend(child_items)
+
+            if el.name == 'p':
+                items = [P_BREAK_BEFORE] + items
+                items.append(P_BREAK_AFTER)
+
+
+        return items
+
+    results = [t for t in text_collection(el, replace_img, base_url) if t is not '']
+
+    if results:
+        # remove <space> if it is first and last or if it is preceded by a <space> or <int> or followed by a <int>
+        # done by replacing it with 0
+        length = len(results)
+        for i  in range(0, length):
+            if (results[i] == ' ' and
+                    (i == 0 or
+                    i == length - 1 or
+                    results[i-1] == ' ' or
+                    isinstance(results[i-1], int) or
+                    results[i+1] == ' ' or
+                    isinstance(results[i+1], int)
+                    )
+                ):
+                results[i] = 0
+
+    if results:
+        # remove leading \n and <int> i.e. next lines
+        while results[0] == '\n' or isinstance(results[0], int):
+            results.pop(0)
+            if not results:
+                break
+    if results:
+        # remove trailing \n and <int> i.e. next lines
+        while results[-1] == '\n' or isinstance(results[-1], int):
+            results.pop(-1)
+            if not results:
+                break
+
+
+    # create final string by concatenating replacing consecutive sequence of <int> by largest value number of \n
+    text = ''
+    count = 0
+    for t in results:
+        if isinstance(t, int):
+            count = max(t, count)
+        else:
+            text = ''.join([text, '\n'*count , t])
+            count = 0
+
+    return text

--- a/mf2py/implied_properties.py
+++ b/mf2py/implied_properties.py
@@ -1,12 +1,16 @@
 from __future__ import unicode_literals, print_function
 from . import mf2_classes
-from .dom_helpers import get_attr, get_children, get_textContent
+from .dom_helpers import get_attr, get_img_src_alt, get_children, get_textContent
 import sys
 
 if sys.version < '3':
     from urlparse import urljoin
+    text_type = unicode
+    binary_type = str
 else:
     from urllib.parse import urljoin
+    text_type = str
+    binary_type = bytes
 
 
 def name(el, base_url=''):
@@ -23,109 +27,118 @@ def name(el, base_url=''):
         name"""
         return val is not None and val != ''
 
-    # if image use alt text if not empty
+    # if image or area use alt text if not empty
     prop_value = get_attr(el, "alt", check_name=("img", "area"))
     if non_empty(prop_value):
-        return [prop_value]
+        return text_type(prop_value)
 
     # if abbreviation use the title if not empty
     prop_value = get_attr(el, "title", check_name="abbr")
     if non_empty(prop_value):
-        return [prop_value]
+        return text_type(prop_value)
 
-    # if only one child
+    # find candidate child or grandchild
+    poss_child = None
     children = list(get_children(el))
     if len(children) == 1:
-        # use alt if child is img
-        prop_value = get_attr(children[0], "alt", check_name="img")
+        poss_child = children[0]
+
+        # ignore if mf2 root
+        if mf2_classes.root(poss_child.get('class',[])):
+            poss_child = None
+
+        # if it is not img, area, abbr then find grandchild
+        if poss_child and poss_child.name not in ("img", "area", "abbr"):
+            grandchildren = list(get_children(poss_child))
+            # if only one grandchild
+            if len(grandchildren) == 1:
+                poss_child = grandchildren[0]
+                # if it is not img, area, abbr or is mf2 root then no possible child
+                if poss_child.name not in ("img", "area", "abbr") or mf2_classes.root(poss_child.get('class',[])):
+                    poss_child = None
+
+    # if a possible child was found
+    if poss_child is not None:
+        # use alt if possible child is img or area
+        prop_value = get_attr(poss_child, "alt", check_name=("img", "area"))
         if non_empty(prop_value):
-            return [prop_value]
+            return text_type(prop_value)
 
-        # use title if child is abbr
-        prop_value = get_attr(children[0], "title", check_name="abbr")
+        # use title if possible child is abbr
+        prop_value = get_attr(poss_child, "title", check_name="abbr")
         if non_empty(prop_value):
-            return [prop_value]
-
-        grandchildren = list(get_children(children[0]))
-        # if only one grandchild
-        if len(grandchildren) == 1:
-            # use alt if grandchild is img
-            prop_value = get_attr(grandchildren[0], "alt", check_name="img")
-            if non_empty(prop_value):
-                return [prop_value]
-
-            # use title if grandchild is title
-            prop_value = get_attr(grandchildren[0], "title", check_name="abbr")
-            if non_empty(prop_value):
-                return [prop_value]
+            return text_type(prop_value)
 
     # use text if all else fails
-    return [get_textContent(el, replace_img=True, base_url=base_url)]
+    # don't replace images in implied name (https://github.com/microformats/microformats2-parsing/issues/35)
+    return get_textContent(el, base_url=base_url)
 
 
-def photo(el, base_url=''):
+def photo(el, dict_class, img_with_alt, base_url=''):
     """Find an implied photo property
 
     Args:
       el (bs4.element.Tag): a DOM element
+      dict_class: a python class used as a dictionary (set by the Parser object)
+      img_with_alt: a flag to enable experimental parsing of alt attribute with img (set by the Parser object)
       base_url (string): the base URL to use, to reconcile relative URLs
 
     Returns:
-      string: the implied photo value
+      string or dictionary: the implied photo value or implied photo as a dictionary with alt value
     """
-    # if element is an image use source if exists
-    prop_value = get_attr(el, "src", check_name="img")
+
+    def get_photo_child(children):
+        "take a list of children and finds a valid child for photo property"
+
+        # if element has one image child use source if exists and img is
+        # not root class
+        poss_imgs = [c for c in children if c.name == 'img']
+        if len(poss_imgs) == 1:
+            poss_img = poss_imgs[0]
+            if not mf2_classes.root(poss_img.get('class', [])):
+                return poss_img
+
+        # if element has one object child use data if exists and object is
+        # not root class
+        poss_objs = [c for c in children if c.name == 'object']
+        if len(poss_objs) == 1:
+            poss_obj = poss_objs[0]
+            if not mf2_classes.root(poss_obj.get('class', [])):
+                return poss_obj
+
+    # if element is an img use source if exists
+    prop_value = get_img_src_alt(el, dict_class, img_with_alt, base_url)
     if prop_value is not None:
-        return [urljoin(base_url, prop_value)]
+        return prop_value
 
     # if element is an object use data if exists
     prop_value = get_attr(el, "data", check_name="object")
     if prop_value is not None:
-        return [prop_value]
+        return text_type(prop_value)
 
-    # if element has one image child use source if exists and img is
-    # not root class
-    poss_imgs = [c for c in get_children(el) if c.name == 'img']
-    if len(poss_imgs) == 1:
-        poss_img = poss_imgs[0]
-        if mf2_classes.root(poss_img.get('class', [])) == []:
-            prop_value = get_attr(poss_img, "src", check_name="img")
-            if prop_value is not None:
-                return [urljoin(base_url, prop_value)]
-
-    # if element has one object child use data if exists and object is
-    # not root class
-    poss_objs = [c for c in get_children(el) if c.name == 'object']
-    if len(poss_objs) == 1:
-        poss_obj = poss_objs[0]
-        if mf2_classes.root(poss_obj.get('class', [])) == []:
-            prop_value = get_attr(poss_obj, "data", check_name="object")
-            if prop_value is not None:
-                return [prop_value]
-
+    # find candidate child or grandchild
+    poss_child = None
     children = list(get_children(el))
-    # if only one child then repeat above in child
-    if len(children) == 1:
-        # if element has one image child use source if exists and img
-        # is not root class
-        poss_imgs = [c for c in get_children(children[0]) if c.name == 'img']
-        if len(poss_imgs) == 1:
-            poss_img = poss_imgs[0]
-            if mf2_classes.root(poss_img.get('class', [])) == []:
-                prop_value = get_attr(poss_img, "src", check_name="img")
-                if prop_value is not None:
-                    return [urljoin(base_url, prop_value)]
 
-        # if element has one object child use data if exists and
-        # object is not root class
-        poss_objs = [c for c in get_children(children[0])
-                     if c.name == 'object']
-        if len(poss_objs) == 1:
-            poss_obj = poss_objs[0]
-            if mf2_classes.root(poss_obj.get('class', [])) == []:
-                prop_value = get_attr(poss_obj, "data", check_name="object")
-                if prop_value is not None:
-                    return [prop_value]
+    poss_child = get_photo_child(children)
+
+    # if no possible child found then look for grandchild if only one child which is not not mf2 root
+    if poss_child is None and len(children) == 1 and not mf2_classes.root(children[0].get('class', [])): 
+
+        grandchildren = list(get_children(children[0]))
+        poss_child = get_photo_child(grandchildren)
+
+    # if a possible child was found parse
+    if poss_child is not None:
+        # img get src
+        prop_value = get_img_src_alt(poss_child, dict_class, img_with_alt, base_url)
+        if prop_value is not None:
+            return prop_value
+
+        # object get data
+        prop_value = get_attr(poss_child, "data", check_name="object")
+        if prop_value is not None:
+            return text_type(prop_value)
 
 
 def url(el, base_url=''):
@@ -138,16 +151,45 @@ def url(el, base_url=''):
     Returns:
       string: the implied url value
     """
-    # if element is a link use its href if exists
+
+    def get_url_child(children):
+        "take a list of children and finds a valid child for url property"
+
+        # if element has one <a> child use if not root class
+        poss_as = [c for c in children if c.name == 'a']
+        if len(poss_as) == 1:
+            poss_a = poss_as[0]
+            if not mf2_classes.root(poss_a.get('class', [])):
+                print("here")
+                return poss_a
+
+        # if element has one area child use if not root class
+        poss_areas = [c for c in children if c.name == 'area']
+        if len(poss_areas) == 1:
+            poss_area = poss_areas[0]
+            if not mf2_classes.root(poss_area.get('class', [])):
+                return poss_area
+
+
+    # if element is a <a> or area use its href if exists
     prop_value = get_attr(el, "href", check_name=("a", "area"))
     if prop_value is not None:  # an empty href is valid
-        return [urljoin(base_url, prop_value)]
+        return text_type(urljoin(base_url, prop_value))
 
-    # if one link child use its href
-    poss_as = [c for c in get_children(el) if c.name == 'a']
-    if len(poss_as) == 1:
-        poss_a = poss_as[0]
-        if mf2_classes.root(poss_a.get('class', [])) == []:
-            prop_value = get_attr(poss_a, "href", check_name="a")
-            if prop_value is not None:
-                return [urljoin(base_url, prop_value)]
+    # find candidate child or grandchild
+    poss_child = None
+    children = list(get_children(el))
+
+    poss_child = get_url_child(children)
+
+    # if no possible child found then look for grandchild if only one child which is not mf2 root
+    if poss_child is None and len(children) == 1 and not mf2_classes.root(children[0].get('class', [])): 
+
+        grandchildren = list(get_children(children[0]))
+        poss_child = get_url_child(grandchildren)
+
+    # if a possible child was found parse
+    if poss_child is not None:
+        prop_value = get_attr(poss_child, "href", check_name=("a", "area"))
+        if prop_value is not None:  # an empty href is valid
+            return text_type(urljoin(base_url, prop_value))

--- a/mf2py/implied_properties.py
+++ b/mf2py/implied_properties.py
@@ -70,8 +70,9 @@ def name(el, base_url=''):
             return text_type(prop_value)
 
     # use text if all else fails
-    # don't replace images in implied name (https://github.com/microformats/microformats2-parsing/issues/35)
-    return get_textContent(el, base_url=base_url)
+    # replace images with alt but not with src in implied name
+    # proposal: https://github.com/microformats/microformats2-parsing/issues/35#issuecomment-393615508
+    return get_textContent(el, replace_img=True, img_to_src=False, base_url=base_url)
 
 
 def photo(el, dict_class, img_with_alt, base_url=''):

--- a/mf2py/mf2_classes.py
+++ b/mf2py/mf2_classes.py
@@ -1,44 +1,61 @@
 from __future__ import unicode_literals, print_function
 
+from .mf_helpers import unordered_list
+
+import re
+
+def _check_format(prefix, cl):
+
+    # older one does not check hyphens
+    #FORMAT_RE = r'%s-([a-z0-9]+-)?[a-z-]+'
+
+    FORMAT_RE = r'%s-([a-z0-9]+-)?[a-z]+(-[a-z]+)*'
+
+    RE = FORMAT_RE % (prefix)
+
+    return re.match(RE + '$', cl)
 
 def root(classes):
     """get all root classnames
     """
-    return [c for c in classes if c.startswith("h-")]
+
+    return unordered_list([c for c in classes if _check_format('h', c)])
 
 
 def properties(classes):
     """get all property (p-*, u-*, e-*, dt-*) classnames
     """
-    return [c.partition("-")[2] for c in classes if c.startswith("p-")
-            or c.startswith("u-") or c.startswith("e-") or c.startswith("dt-")]
 
+    return unordered_list([c.partition("-")[2] for c in classes if _check_format('(p|u|dt|e)', c)])
+
+def property_classes(classes):
+    """get all property (p-*, u-*, e-*, dt-*) classnames with prefix
+    """
+
+    return unordered_list([c for c in classes if _check_format('(p|u|dt|e)', c)])
 
 def text(classes):
     """get text property (p-*) names
     """
-    return [c.partition("-")[2] for c in classes if c.startswith("p-")]
+
+    return unordered_list([c.partition("-")[2] for c in classes if _check_format('p', c)])
 
 
 def url(classes):
     """get URL property (u-*) names
     """
-    return [c.partition("-")[2] for c in classes if c.startswith("u-")]
+
+    return unordered_list([c.partition("-")[2] for c in classes if _check_format('u', c)])
 
 
 def datetime(classes):
     """get datetime property (dt-*) names
     """
-    return [c.partition("-")[2] for c in classes if c.startswith("dt-")]
 
+    return unordered_list([c.partition("-")[2] for c in classes if _check_format('dt', c)])
 
 def embedded(classes):
     """get embedded property (e-*) names
     """
-    return [c.partition("-")[2] for c in classes if c.startswith("e-")]
 
-def property_classes(classes):
-    """get all property (p-*, u-*, e-*, dt-*) classnames with prefix
-    """
-    return [c for c in classes if c.startswith("p-")
-            or c.startswith("u-") or c.startswith("e-") or c.startswith("dt-")]
+    return unordered_list([c.partition("-")[2] for c in classes if _check_format('e', c)])

--- a/mf2py/mf_helpers.py
+++ b/mf2py/mf_helpers.py
@@ -1,3 +1,5 @@
+# don't need anymore defer to mf2util instead (mf2util does not have this functionality)
+
 def get_url(mf):
     """Given a property value that may be a list of simple URLs or complex
     h-* dicts (with a url property), extract a list of URLs. This is useful
@@ -9,6 +11,7 @@ def get_url(mf):
     Returns:
       list: a list of URLs
     """
+
     urls = []
     for item in mf:
         if isinstance(item, basestring):
@@ -18,3 +21,9 @@ def get_url(mf):
             urls.extend(item.get('properties', {}).get('url', []))
 
     return urls
+
+def unordered_list(l):
+    """given a list, returns another list with unique and alphabetically sorted elements.
+    use for HTML attributes that have no semantics to their order e.g. class, rel.
+    """
+    return sorted(set(l))

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -1,7 +1,7 @@
 """functions to parse the properties of elements"""
 from __future__ import unicode_literals, print_function
 
-from .dom_helpers import get_attr, get_children, get_textContent
+from .dom_helpers import get_attr, get_img_src_alt, get_children, get_textContent
 from .datetime_helpers import normalize_datetime, DATETIME_RE, TIME_RE
 from . import value_class_pattern
 
@@ -36,12 +36,16 @@ def text(el, base_url=''):
     return prop_value
 
 
-def url(el, base_url=''):
+def url(el, dict_class, img_with_alt, base_url=''):
     """Process u-* properties"""
 
     prop_value = get_attr(el, "href", check_name=("a", "area", "link"))
     if prop_value is None:
-        prop_value = get_attr(el, "src", check_name=("img", "audio", "video", "source"))
+        prop_value = get_img_src_alt(el, dict_class, img_with_alt, base_url)
+        if prop_value is not None:
+            return prop_value
+    if prop_value is None:
+        prop_value = get_attr(el, "src", check_name=("audio", "video", "source"))
     if prop_value is None:
         prop_value = get_attr(el, "poster", check_name="video")
     if prop_value is None:

--- a/mf2py/version.py
+++ b/mf2py/version.py
@@ -1,4 +1,4 @@
 # Define the version number. This class is exec'd by setup.py to read
 # the value without loading mf2py (loading mf2py is bad if its dependencies
 # haven't been installed yet, which is common during setup)
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/test/examples/backcompat/hentry_content_html.html
+++ b/test/examples/backcompat/hentry_content_html.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <title>Backcompat Properties</title>
+</head>
+<body>
+
+<article class="hentry">
+    <section class="entry-content">
+        <p class="entry-summary">This is a summary</p> 
+        <p>This is <a href="/tags/mytag" rel="tag">mytag</a> inside content. </p>
+    </section>
+</article>
+
+</body>
+</html>

--- a/test/examples/backcompat/hentry_with_rel_bookmark.html
+++ b/test/examples/backcompat/hentry_with_rel_bookmark.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>Backcompat rel=bookmark</title>
+  </head>
+  <body>
+    <article class="hentry">
+      <a rel="bookmark" href="https://example.com/bookmark">rhinoceros</a>
+      <a rel="bookmark u-url" href="https://example.com/bookmark-url">rhinoceros</a>
+      <a rel="u-url" href="https://example.com/url">rhinoceros</a>
+    </article>
+  </body>
+</html>

--- a/test/examples/backcompat/hentry_with_rel_tag_entry_title.html
+++ b/test/examples/backcompat/hentry_with_rel_tag_entry_title.html
@@ -1,0 +1,3 @@
+<article class="hentry">
+      <a rel="tag" class="entry-title" href="https://example.com/tags/cat">rhinoceros</a>
+</article>

--- a/test/examples/backcompat/hfeed_with_rel_tag.html
+++ b/test/examples/backcompat/hfeed_with_rel_tag.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
-    <title>Backcompat rel=tag on hentry</title>
+    <title>Backcompat rel=tag on hfeed</title>
   </head>
   <body>
-    <article class="hentry">
+    <article class="hfeed">
       <a rel="tag" href="https://example.com/tags/cat">rhinoceros</a>
       <a rel="tag" href="https://example.com/tags/dog/">giraffe</a>
       <a rel="tag" href="https://example.com/tags/mountain%20lion/">hyena</a>

--- a/test/examples/backcompat/hrecipe_with_rel_tag.html
+++ b/test/examples/backcompat/hrecipe_with_rel_tag.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
-    <title>Backcompat rel=tag on hentry</title>
+    <title>Backcompat rel=tag on hrecipe</title>
   </head>
   <body>
-    <article class="hentry">
+    <article class="hrecipe">
       <a rel="tag" href="https://example.com/tags/cat">rhinoceros</a>
       <a rel="tag" href="https://example.com/tags/dog/">giraffe</a>
       <a rel="tag" href="https://example.com/tags/mountain%20lion/">hyena</a>

--- a/test/examples/backcompat/hreview_hentry_with_rel_tag_bookmark.html
+++ b/test/examples/backcompat/hreview_hentry_with_rel_tag_bookmark.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
-    <title>Backcompat rel=tag on hentry</title>
+    <title>Backcompat rel=tag and rel=bookmark on hreview and hentry</title>
   </head>
   <body>
-    <article class="hentry">
+    <article class="hreview hentry">
       <a rel="tag" href="https://example.com/tags/cat">rhinoceros</a>
       <a rel="tag" href="https://example.com/tags/dog/">giraffe</a>
       <a rel="tag" href="https://example.com/tags/mountain%20lion/">hyena</a>
@@ -15,6 +15,9 @@
       <!-- throw some mf2 at the parser to ignore -->
       <a rel="tag" class="p-category" href="https://example.com/tags/mouse">elephant</a>
       <a rel="tag" class="u-category" href="https://example.com/tags/meerkat">dinosaur</a>
+      <a rel="bookmark" href="https://example.com/bookmark">rhinoceros</a>
+      <a rel="bookmark u-url" href="https://example.com/bookmark-url">rhinoceros</a>
+      <a rel="u-url" href="https://example.com/url">rhinoceros</a>
     </article>
   </body>
 </html>

--- a/test/examples/backcompat/hreview_nested_card_event_product.html
+++ b/test/examples/backcompat/hreview_nested_card_event_product.html
@@ -1,0 +1,16 @@
+<article class="hreview">
+    <div class="item vevent">
+        <span class="summary">event name</span>
+        <a class="url" href="http://example.com/event-url">event url</a>
+    </div>
+
+    <div class="item vcard">
+        <span class="fn">card name</span>
+        <a class="url" href="http://example.com/card-url">card url</a>
+    </div>
+
+    <div class="item hproduct">
+        <span class="fn">product name</span>
+        <a class="url" href="http://example.com/product-url">product url</a>
+    </div>
+</article>

--- a/test/examples/backcompat/hreview_with_rel_tag_bookmark.html
+++ b/test/examples/backcompat/hreview_with_rel_tag_bookmark.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
-    <title>Backcompat rel=tag on hentry</title>
+    <title>Backcompat rel=tag and rel=bookmark on hreview</title>
   </head>
   <body>
-    <article class="hentry">
+    <article class="hreview">
       <a rel="tag" href="https://example.com/tags/cat">rhinoceros</a>
       <a rel="tag" href="https://example.com/tags/dog/">giraffe</a>
       <a rel="tag" href="https://example.com/tags/mountain%20lion/">hyena</a>
@@ -15,6 +15,11 @@
       <!-- throw some mf2 at the parser to ignore -->
       <a rel="tag" class="p-category" href="https://example.com/tags/mouse">elephant</a>
       <a rel="tag" class="u-category" href="https://example.com/tags/meerkat">dinosaur</a>
+      <a rel="bookmark" href="https://example.com/not-bookmark">rhinoceros</a>
+      <a rel="self bookmark" href="https://example.com/bookmark">rhinoceros</a>
+      <a rel="bookmark" href="https://example.com/not-bookmark">rhinoceros</a>
+      <a rel="self bookmark u-url" href="https://example.com/bookmark-url">rhinoceros</a>
+      <a rel="u-url" href="https://example.com/url">rhinoceros</a>
     </article>
   </body>
 </html>

--- a/test/examples/class_names_format.html
+++ b/test/examples/class_names_format.html
@@ -1,0 +1,5 @@
+<article class="h-x-test h-p3k-entry h-feed h-Entry h-p3k-fEed h--d h-test-">
+    <a class="u-url u-Url u-p3k-url u--url u-url-" href="example.com" >URL </a>
+    <span class="p-name p-nAme p-p3k-name p--name p-name-" >name</span>
+</article>
+

--- a/test/examples/datetimes.html
+++ b/test/examples/datetimes.html
@@ -107,5 +107,38 @@
 
  </div>
 
+ <div class="h-event">
+   <h1 class="p-name">AM PM conversion</h1>
+
+   <p> When:
+     <span class="dt-start">
+       <span class="value" title="June 1, 2014">2014-06-01</span>
+       <span class="value">12:30am</span>
+       (UTC<span class="value">-06:00</span>)
+       –
+       <span class="dt-end">12:15p.m.</span>
+   </p>
+
+   <p> When:
+     <span class="dt-start">
+       <span class="value" title="June 1, 2014">2014-06-01</span>
+       <span class="value">12:30AM</span>
+       (UTC<span class="value">-06:00</span>)
+       –
+       <span class="dt-end">12:15P.M.</span>
+   </p>
+ </div>
+
+ <div class="h-event">
+   <h1 class="p-name">Ordinal date</h1>
+
+   <p> When:
+     <span class="dt-start">
+       <span class="value">2016-062</span>
+       <span class="value">12:30AM</span>
+       (UTC<span class="value">-06:00</span>)
+   </p>
+ </div>
+
 </body>
 </html>

--- a/test/examples/experimental/img_with_alt.html
+++ b/test/examples/experimental/img_with_alt.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <title>Photo with alt attribute</title>
+</head>
+<body>
+<article class="h-entry">
+  <span class="p-name">name</span>
+  <img class="u-photo" src="/photo.jpg"/>
+</article>
+
+<article class="h-entry">
+  <span class="p-name">name</span>
+  <img class="u-url" src="/photo.jpg" alt="alt text" />
+</article>
+
+<article class="h-entry">
+  <span class="p-name">name</span>
+  <img class="u-in-reply-to" src="/photo.jpg" alt="" />
+</article>
+
+<article class="h-entry">
+  <span class="p-name">name</span>
+  <img class="u-in-reply-to h-cite" src="/photo.jpg"/>
+</article>
+
+<article class="h-entry">
+  <span class="p-name">name</span>
+  <img class="u-in-reply-to h-cite" src="/photo.jpg" alt="alt text" />
+</article>
+
+<article class="h-entry">
+  <span class="p-name">name</span>
+  <img class="u-in-reply-to h-cite" src="/photo.jpg" alt="" />
+</article>
+</body>
+</html>

--- a/test/examples/implied_properties/implied_photo.html
+++ b/test/examples/implied_properties/implied_photo.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <title>Implied Photo</title>
+</head>
+<body>
+
+<!--if img.h-x[src], then use src for photo-->
+<img class="h-entry" src="http://example.com/photo.jpg"/>
+
+<!--else if object.h-x[data] then use data for photo-->
+<object class="h-entry" data="http://example.com/photo.jpg"></object>
+
+<!--else if .h-x>img[src]:only-of-type:not[.h-*] then use that img src for photo-->
+<article class="h-entry">
+    <img src="http://example.com/photo.jpg"/>
+</article>
+
+<article class="h-entry">
+    <img src="http://example.com/photo.jpg"/>
+    <span> test </span>
+</article>
+
+<!--else if .h-x>object[data]:only-of-type:not[.h-*] then use that object’s data for photo-->
+<article class="h-entry">
+    <object data="http://example.com/photo.jpg"></object>
+</article>
+
+<article class="h-entry">
+    <object data="http://example.com/photo.jpg"></object>
+    <span> test </span>
+</article>
+
+<!--else if .h-x>:only-child:not[.h-*]>img[src]:only-of-type:not[.h-*], then use that img’s src for photo-->
+<article class="h-entry">
+    <div>
+        <img src="http://example.com/photo.jpg"/>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <img src="http://example.com/photo.jpg"/>
+        <span>test</span>
+    </div>
+</article>
+
+<!--else if .h-x>:only-child:not[.h-*]>object[data]:only-of-type:not[.h-*], then use that object’s data for photo -->
+
+<article class="h-entry">
+    <div>
+        <object data="http://example.com/photo.jpg"></object>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <object data="http://example.com/photo.jpg"></object>
+        <span>test</span>
+    </div>
+</article>
+
+<!--priority tests; prefer img over object-->
+
+<article class="h-entry">
+    <object data="http://example.com/photo2.jpg"></object>
+    <img src="http://example.com/photo.jpg"/>
+</article>
+
+<article class="h-entry">
+    <div>
+        <object data="http://example.com/photo2.jpg"></object>
+        <img src="http://example.com/photo.jpg"/>
+    </div>
+</article>
+
+<!-- no photo tests -->
+<article class="h-entry">
+    <img src="http://example.com/photo.jpg"/>
+    <img src="http://example.com/photo2.jpg"/>
+</article>
+
+<article class="h-entry">
+    <img class="h-cite" src="http://example.com/photo.jpg"/>
+</article>
+
+<article class="h-entry">
+    <object data="http://example.com/photo.jpg"></object>
+    <object data="http://example.com/photo2.jpg"></object>
+</article>
+
+<article class="h-entry">
+    <object class="h-cite" data="http://example.com/photo.jpg"></object>
+</article>
+
+
+<article class="h-entry">
+    <div>
+        <img src="http://example.com/photo.jpg"/>
+    </div>
+    <span>test</span>
+</article>
+
+<article class="h-entry">
+    <div class="h-cite">
+        <img src="http://example.com/photo.jpg"/>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <img src="http://example.com/photo.jpg"/>
+        <img src="http://example.com/photo2.jpg"/>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div class="h-cite">
+        <img class="h-cite" src="http://example.com/photo.jpg"/>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <object data="http://example.com/photo.jpg"></object>
+    </div>
+    <span>test</span>
+</article>
+
+<article class="h-entry">
+    <div class="h-cite">
+        <object data="http://example.com/photo.jpg"></object>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <object data="http://example.com/photo.jpg"></object>
+        <object data="http://example.com/photo2.jpg"></object>
+    </div>
+</article>
+
+</body>
+</html>

--- a/test/examples/implied_properties/implied_properties.html
+++ b/test/examples/implied_properties/implied_properties.html
@@ -11,6 +11,8 @@
 
 	<a class="h-card" href="http://tommorris.org/"><img src="http://tommorris.org/photo.png" alt="" />Tom Morris</a>
 
+	<a class="h-card" href="http://tommorris.org/"><img src="http://tommorris.org/photo.png"/>Tom Morris</a>
+
 	<a class="h-card" href="http://tommorris.org/"><img src="http://tommorris.org/photo.png" alt="Tom Morris" /></a>
 
 	<img class="h-card" src="http://tommorris.org/photo.png" alt="Tom Morris" />

--- a/test/examples/implied_properties/implied_url.html
+++ b/test/examples/implied_properties/implied_url.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <title>Implied Photo</title>
+</head>
+<body>
+
+<!--if a.h-x[href] or area.h-x[href] then use that [href] for url-->
+<a class="h-entry" href="http://example.com">this be link</a>
+
+<area class="h-entry" href="http://example.com"/>
+
+<!--else if .h-x>a[href]:only-of-type:not[.h-*], then use that [href] for url-->
+<article class="h-entry">
+    <a href="http://example.com">this be link</a>
+</article>
+
+<article class="h-entry">
+    <a href="http://example.com">this be link</a>
+    <span> test </span>
+</article>
+
+<!--else if .h-x>area[href]:only-of-type:not[.h-*], then use that [href] for url-->
+<article class="h-entry">
+    <area href="http://example.com"/>
+</article>
+
+<article class="h-entry">
+    <area href="http://example.com"/>
+    <span> test </span>
+</article>
+
+<!--else if .h-x>:only-child:not[.h-*]>a[href]:only-of-type:not[.h-*], then use that [href] for url-->
+<article class="h-entry">
+    <div>
+        <a href="http://example.com">this be link</a>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <a href="http://example.com">this be link</a>
+        <span>test</span>
+    </div>
+</article>
+
+<!--else if .h-x>:only-child:not[.h-*]>area[href]:only-of-type:not[.h-*], then use that [href] for url -->
+<article class="h-entry">
+    <div>
+        <area href="http://example.com"/>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <area href="http://example.com"/>
+        <span>test</span>
+    </div>
+</article>
+
+<!--priority tests; prefer <a> over <area>-->
+
+<article class="h-entry">
+    <area href="http://example.com/not"/>
+    <a href="http://example.com">this be link</a>
+</article>
+
+<article class="h-entry">
+    <div>
+        <area href="http://example.com/not"/>
+        <a href="http://example.com">this be link</a>
+    </div>
+</article>
+
+<!-- no url tests -->
+<article class="h-entry">
+    <a href="http://example.com">this be link</a>
+    <a href="http://example.com/2">this be link</a>
+</article>
+
+<article class="h-entry">
+    <a class="h-cite" href="http://example.com">this be link</a>
+</article>
+
+<article class="h-entry">
+    <area href="http://example.com"/>
+    <area href="http://example.com/2"/>
+</article>
+
+<article class="h-entry">
+    <area class="h-cite" href="http://example.com"/>
+</article>
+
+
+<article class="h-entry">
+    <div>
+        <a href="http://example.com">this be link</a>
+    </div>
+    <span>test</span>
+</article>
+
+<article class="h-entry">
+    <div class="h-cite">
+        <a href="http://example.com">this be link</a>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <a href="http://example.com">this be link</a>
+        <a href="http://example.com/2">this be link</a>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div class="h-cite">
+        <a class="h-cite" href="http://example.com">this be link</a>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <area href="http://example.com"/>
+    </div>
+    <span>test</span>
+</article>
+
+<article class="h-entry">
+    <div class="h-cite">
+        <area href="http://example.com"/>
+    </div>
+</article>
+
+<article class="h-entry">
+    <div>
+        <area href="http://example.com"/>
+        <area href="http://example.com/2"/>
+    </div>
+</article>
+
+
+</body>
+</html>

--- a/test/examples/ordering_dedup.html
+++ b/test/examples/ordering_dedup.html
@@ -1,0 +1,10 @@
+<article class="h-x-test h-product h-feed h-entry h-feed">
+    <a class="u-url u-url" href="example.com" >URL </a>
+    <span class="p-name p-name" >name</span>
+    <a class="p-name u-url" href="example.com/2" >URL name</a>
+    <a rel="me bookmark" href="example.com/rel">author a</a>
+    <a rel="bookmark author bookmark" href="example.com/rel">author a</a>
+    <a href="example.com/lang" rel="lang" hreflang="de"></a>
+    <a href="example.com/lang" rel="lang" hreflang="en"></a>
+</article>
+

--- a/test/examples/value_name_whitespace.html
+++ b/test/examples/value_name_whitespace.html
@@ -1,0 +1,71 @@
+<div class="h-entry">
+  <div class="e-content p-name"><p>Hello World</p></div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name">
+    <p>Hello World</p>
+  </div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name">Hello
+World</div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name"><p>Hello<br>World</p></div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name"><p>Hello<br>
+World</p></div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name"><p>Hello</p><p>World</p></div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name">Hello<br>
+    World</div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name"><br>Hello<br>World<br></div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name">
+    <p>One</p>
+    <p>Two</p>
+    <p>Three</p>
+  </div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name">
+    <pre>One
+Two
+Three</pre>
+  </div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name">
+    Hello World
+    <pre>
+      one
+      two
+      three
+    </pre>
+  </div>
+</div>
+
+<div class="h-entry">
+<div class="e-content">
+<span class="p-name">Correct name</span>
+
+<span class="p-summary">Correct summary</span>
+</div>
+</div>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -43,15 +43,22 @@ def test_open_file():
     assert_true(type(p.to_dict()) is dict)
 
 def test_doc_tag():
-    # test that strings, BS doc and BS tags are all parsed
+    # test that strings, BS doc and BS tags are all parsed and in the latter cases copies are made but are the same stuff
     doc = '''<article class="h-entry"></article>'''
     soup = BeautifulSoup(doc)
+
     parse_string = Parser(doc).to_dict()
-    assert 'h-entry' in parse_string['items'][0]['type']
-    parse_doc = Parser(soup).to_dict()
-    assert 'h-entry' in parse_doc['items'][0]['type']
-    parse_tag = Parser(soup.article).to_dict()
-    assert 'h-entry' in parse_tag['items'][0]['type']
+    assert_true('h-entry' in parse_string['items'][0]['type'])
+
+    p = Parser(soup)
+    assert_true('h-entry' in p.to_dict()['items'][0]['type'])
+    assert_false(soup is p.__doc__)
+    assert_true(soup == p.__doc__)
+
+    p = Parser(soup.article)
+    assert_true('h-entry' in p.to_dict()['items'][0]['type'])
+    assert_false(soup.article is p.__doc__)
+    assert_true(soup.article == p.__doc__)
 
 @mock.patch('requests.get')
 def test_user_agent(getter):
@@ -174,7 +181,16 @@ def test_datetime_vcp_parsing():
                  "2014-06-01 12:30-06:00")
     assert_equal(result["items"][9]["properties"]["start"][0],
                  "2014-06-01 12:30-06:00")
-
+    assert_equal(result["items"][10]["properties"]["start"][0],
+                 "2014-06-01 00:30-06:00")
+    assert_equal(result["items"][10]["properties"]["end"][0],
+                 "2014-06-01 12:15")
+    assert_equal(result["items"][10]["properties"]["start"][1],
+                 "2014-06-01 00:30-06:00")
+    assert_equal(result["items"][10]["properties"]["end"][1],
+                 "2014-06-01 12:15")
+    assert_equal(result["items"][11]["properties"]["start"][0],
+                 "2016-03-02 00:30-06:00")
 
 def test_dt_end_implied_date():
     """Test that events with dt-start and dt-end use the implied date rule
@@ -204,7 +220,7 @@ def test_embedded_parsing():
         '   <p>Blah.</p>\n   <p>Blah blah blah.</p>')
     assert_equal(
         result["items"][0]["properties"]["content"][0]["value"],
-        'Blah blah blah blah blah.\n   Blah.\n   Blah blah blah.')
+        'Blah blah blah blah blah.\nBlah.\nBlah blah blah.')
 
 
 def test_hoisting_nested_hcard():
@@ -252,6 +268,34 @@ def test_template_parse():
     result = parse_fixture("template_tag.html")
     assert_equal(0, len(result["items"]))
 
+def test_ordering_dedup():
+    ''' test that classes are dedeuped and alphabetically ordered '''
+
+    result = parse_fixture("ordering_dedup.html")
+    item = result['items'][0]
+    assert_equal(['h-entry', 'h-feed', 'h-product', 'h-x-test'], item['type'])
+    assert_equal(['example.com', 'example.com/2'], item['properties']['url'])
+    assert_equal(['name', 'URL name'], item['properties']['name'])
+    assert_equal(['author', 'bookmark', 'me'], result['rel-urls']['example.com/rel']['rels'])
+    assert_equal('de', result['rel-urls']['example.com/lang']['hreflang'])
+
+def test_class_names_format():
+    ''' test that only classes with letters and possibly numbers in the vendor prefix part are used '''
+
+    result = parse_fixture("class_names_format.html")
+    item = result['items'][0]
+    assert_equal(['h-feed', 'h-p3k-entry', 'h-x-test'], item['type'])
+    assert 'url' in item['properties']
+    assert 'p3k-url' in item['properties']
+    assert 'Url' not in item['properties']
+    assert '-url' not in item['properties']
+    assert 'url-' not in item['properties']
+
+    assert 'name' in item['properties']
+    assert 'p3k-name' in item['properties']
+    assert 'nAme' not in item['properties']
+    assert '-name' not in item['properties']
+    assert 'name-' not in item['properties']
 
 def test_area_uparsing():
     result = parse_fixture("area.html")
@@ -386,6 +430,7 @@ def test_nested_values():
 
 def test_implied_name():
     result = parse_fixture("implied_properties/implied_properties.html")
+
     for i in range(6):
         assert_equal(result["items"][i]["properties"]["name"][0], "Tom Morris")
 
@@ -399,6 +444,31 @@ def test_implied_url():
     # href="" is relative to the base url
     assert_equal(result["items"][5]["properties"]["url"][0], "http://foo.com/")
 
+def test_implied_photo():
+
+    result = parse_fixture("implied_properties/implied_photo.html")
+
+    for i in range(12):
+        photos = result["items"][i]["properties"]["photo"]
+        assert_equal(len(photos), 1)
+        assert_equal(photos[0], "http://example.com/photo.jpg")
+
+    # tests for no photo
+    for i in range(12, 23):
+        assert_false("photo" in result["items"][i]["properties"])
+
+def test_implied_url():
+
+    result = parse_fixture("implied_properties/implied_url.html")
+
+    for i in range(12):
+        urls = result["items"][i]["properties"]["url"]
+        assert_equal(len(urls), 1)
+        assert_equal(urls[0], "http://example.com")
+
+    # tests for no url
+    for i in range(12, 23):
+        assert_false("url" in result["items"][i]["properties"])
 
 def test_implied_nested_photo():
     result = parse_fixture("implied_properties/implied_properties.html", url="http://bar.org")
@@ -476,7 +546,46 @@ def test_simple_person_reference_implied():
                  {'name': ['Frances Berriman']})
 
 
+def test_value_name_whitespace():
+    result = parse_fixture("value_name_whitespace.html")
+
+    for i in range(3):
+        assert_equal(result["items"][i]["properties"]["content"][0]["value"], "Hello World")
+        assert_equal(result["items"][i]["properties"]["name"][0], "Hello World")
+
+    for i in range(3, 8):
+        assert_equal(result["items"][i]["properties"]["content"][0]["value"], "Hello\nWorld")
+        assert_equal(result["items"][i]["properties"]["name"][0], "Hello\nWorld")
+
+    for i in range(8, 10):
+        assert_equal(result["items"][i]["properties"]["content"][0]["value"], "One\nTwo\nThree")
+        assert_equal(result["items"][i]["properties"]["name"][0], "One\nTwo\nThree")
+
+    assert_equal(result["items"][10]["properties"]["content"][0]["value"], "Hello World      one\n      two\n      three\n    ")
+    assert_equal(result["items"][10]["properties"]["name"][0], "Hello World      one\n      two\n      three\n    ")
+
+    assert_equal(result["items"][11]["properties"]["content"][0]["value"], "Correct name Correct summary")
+    assert_equal(result["items"][11]["properties"]["name"][0], "Correct name")
+
 # backcompat tests
+
+def test_doc_tag_backcompat():
+    # test that strings, BS doc and BS tags are all parsed and in the latter cases copies are made and are modified by backcompat
+    doc = '''<article class="hentry"></article>'''
+    soup = BeautifulSoup(doc)
+
+    parse_string = Parser(doc).to_dict()
+    assert_true('h-entry' in parse_string['items'][0]['type'])
+
+    p = Parser(soup)
+    assert_true('h-entry' in p.to_dict()['items'][0]['type'])
+    assert_false(soup is p.__doc__)
+    assert_false(soup == p.__doc__)
+
+    p = Parser(soup.article)
+    assert_true('h-entry' in p.to_dict()['items'][0]['type'])
+    assert_false(soup.article is p.__doc__)
+    assert_false(soup.article == p.__doc__)
 
 def test_backcompat_hentry():
     result = parse_fixture("backcompat/hentry.html")
@@ -504,6 +613,27 @@ def test_backcompat_hproduct_nested_hreview():
     result = parse_fixture("backcompat/hproduct_hreview_nested.html")
     assert_equal(['h-review'], result["items"][0]["children"][0]['type'])
 
+def test_backcompat_hreview_nested_card_event_product():
+    result = parse_fixture("backcompat/hreview_nested_card_event_product.html")
+    assert_equal(['h-review'], result["items"][0]['type'])
+    items = result["items"][0]["properties"]['item']
+    assert_equal(3, len(items))
+
+    event = items[0]
+    assert_equal(['h-event'], event['type'])
+    assert_equal(['http://example.com/event-url'], event['properties']['url'])
+    assert_equal(['event name'], event['properties']['name'])
+
+    card = items[1]
+    assert_equal(['h-card'], card['type'])
+    assert_equal(['http://example.com/card-url'], card['properties']['url'])
+    assert_equal(['card name'], card['properties']['name'])
+
+    product = items[2]
+    assert_equal(['h-product'], product['type'])
+    assert_equal(['http://example.com/product-url'], product['properties']['url'])
+    assert_equal(['product name'], product['properties']['name'])
+
 
 def test_backcompat_rel_bookmark():
     """Confirm that rel=bookmark inside of an h-entry is converted
@@ -519,13 +649,48 @@ def test_backcompat_rel_bookmark():
         assert_equal(['h-entry'], result['items'][ii]['type'])
         assert_equal([url], result['items'][ii]['properties']['url'])
 
+def test_backcompat_rel_bookmark():
+    """Confirm that rel=bookmark inside of an hentry and hreview is converted
+    to a u-url and original u-url is ignored
+    """
+
+    tests = ['backcompat/hentry_with_rel_bookmark.html', 'backcompat/hreview_with_rel_tag_bookmark.html']
+
+    results = [parse_fixture(x) for x in tests]
+
+    for result in results:
+        assert_equal(['https://example.com/bookmark', 'https://example.com/bookmark-url'], result['items'][0]['properties']['url'])
 
 def test_backcompat_rel_tag():
-    """Confirm that rel=tag inside of an h-entry is converted
+    """Confirm that rel=tag inside of an hentry is converted
     to a p-category and the last path segment of the href is used.
     """
-    result = parse_fixture('backcompat/hentry_with_rel_tag.html')
-    assert_equal(['cat', 'dog', 'mountain lion'], result['items'][0]['properties']['category'])
+
+    tests = ['backcompat/hentry_with_rel_tag.html', 'backcompat/hfeed_with_rel_tag.html', 'backcompat/hrecipe_with_rel_tag.html', 'backcompat/hreview_with_rel_tag_bookmark.html']
+
+    results = [parse_fixture(x) for x in tests]
+    for result in results:
+        assert_equal(['cat', 'dog', 'mountain lion', 'mouse', 'meerkat'], result['items'][0]['properties']['category'])
+
+def test_backcompat_rel_tag_entry_title():
+    """Confirm that other backcompat properties on a rel=tag are parsed
+    """
+
+    result = parse_fixture('backcompat/hentry_with_rel_tag_entry_title.html')
+    assert_equal(['cat'], result['items'][0]['properties']['category'])
+    assert_equal(['rhinoceros'], result['items'][0]['properties']['name'])
+
+def test_backcompat_rel_multiple_root():
+    """Confirm that rel=tag and rel=bookmark inside of an hentry+hreview is parsed correctly"""
+
+    result = parse_fixture('backcompat/hreview_hentry_with_rel_tag_bookmark.html')
+
+    assert_equal(len(result['items']), 1)
+    assert_true('h-entry' in result['items'][0]['type'])
+    assert_true('h-review' in result['items'][0]['type'])
+
+    assert_equal(['cat', 'dog', 'mountain lion', 'mouse', 'meerkat'], result['items'][0]['properties']['category'])
+    assert_equal(['https://example.com/bookmark', 'https://example.com/bookmark-url'], result['items'][0]['properties']['url'])
 
 def test_backcompat_ignore_mf1_root_if_mf2_present():
     """Confirm that mf1 root class is ignored if another mf2 root class is present.
@@ -585,11 +750,81 @@ def test_backcompat_nested_mf1_in_mf2_e_content():
 
     assert_equal('<div class="hentry">\n<span class="entry-title">Correct name</span>\n\n<span class="entry-summary">Correct summary</span>\n</div>', mf2_entry['properties']['content'][0]['html'])
 
-    assert_equal('Correct name\n\nCorrect summary', mf2_entry['properties']['content'][0]['value'])
+    assert_equal('Correct name Correct summary', mf2_entry['properties']['content'][0]['value'])
 
     assert_equal('h-entry', mf1_entry['type'][0])
     assert_equal('Correct name', mf1_entry['properties']['name'][0])
     assert_equal('Correct summary', mf1_entry['properties']['summary'][0])
+
+def test_backcompat_hentry_content_html():
+    """Confirm that mf1 entry-content html is parsed as authored without mf2 replacements
+    """
+    result = parse_fixture('backcompat/hentry_content_html.html')
+
+    entry = result['items'][0]
+
+    assert_equal('<p class="entry-summary">This is a summary</p> \n        <p>This is <a href="/tags/mytag" rel="tag">mytag</a> inside content. </p>', entry['properties']['content'][0]['html'])
+
+
+# experimental features tests
+
+def test_photo_with_alt():
+    """Confirm that alt text in img is parsed with feature flag img_with_alt under as a u-* property and implied photo
+    """
+
+    path = 'experimental/img_with_alt.html'
+
+    # without flag
+    result = parse_fixture(path)
+
+    # experimental img_with_alt=True
+    with open(os.path.join(TEST_DIR, path)) as f:
+        exp_result = Parser(doc=f, html_parser='html5lib', img_with_alt=True).to_dict()
+
+    # simple img with u-*
+    assert_equal('/photo.jpg', result['items'][0]['properties']['photo'][0])
+    assert_equal('/photo.jpg', exp_result['items'][0]['properties']['photo'][0])
+
+    assert_equal('/photo.jpg', result['items'][1]['properties']['url'][0])
+    assert_equal('/photo.jpg', exp_result['items'][1]['properties']['url'][0]['value'])
+    assert_equal('alt text', exp_result['items'][1]['properties']['url'][0]['alt'])
+
+    assert_equal('/photo.jpg', result['items'][2]['properties']['in-reply-to'][0])
+    assert_equal('/photo.jpg', exp_result['items'][2]['properties']['in-reply-to'][0]['value'])
+    assert_equal('', exp_result['items'][2]['properties']['in-reply-to'][0]['alt'])
+
+    # img with u-* and h-* example
+    assert_true('h-cite' in result['items'][3]['properties']['in-reply-to'][0]['type'])
+    assert_equal('/photo.jpg', result['items'][3]['properties']['in-reply-to'][0]['properties']['photo'][0])
+    assert_equal('/photo.jpg', result['items'][3]['properties']['in-reply-to'][0]['value'])
+    assert_false('alt' in result['items'][3]['properties']['in-reply-to'][0])
+
+    assert_true('h-cite' in exp_result['items'][3]['properties']['in-reply-to'][0]['type'])
+    assert_equal('/photo.jpg', exp_result['items'][3]['properties']['in-reply-to'][0]['properties']['photo'][0])
+    assert_equal('/photo.jpg', exp_result['items'][3]['properties']['in-reply-to'][0]['value'])
+    assert_false('alt' in exp_result['items'][3]['properties']['in-reply-to'][0])
+
+    assert_true('h-cite' in result['items'][4]['properties']['in-reply-to'][0]['type'])
+    assert_equal('/photo.jpg', result['items'][4]['properties']['in-reply-to'][0]['properties']['photo'][0])
+    assert_equal('/photo.jpg', result['items'][4]['properties']['in-reply-to'][0]['value'])
+    assert_false('alt' in result['items'][4]['properties']['in-reply-to'][0])
+
+    assert_true('h-cite' in exp_result['items'][4]['properties']['in-reply-to'][0]['type'])
+    assert_equal('/photo.jpg', exp_result['items'][4]['properties']['in-reply-to'][0]['properties']['photo'][0]['value'])
+    assert_equal('/photo.jpg', exp_result['items'][4]['properties']['in-reply-to'][0]['value'])
+    assert_equal('alt text', exp_result['items'][4]['properties']['in-reply-to'][0]['properties']['photo'][0]['alt'])
+    assert_equal('alt text', exp_result['items'][4]['properties']['in-reply-to'][0]['alt'])
+
+    assert_true('h-cite' in result['items'][5]['properties']['in-reply-to'][0]['type'])
+    assert_equal('/photo.jpg', result['items'][5]['properties']['in-reply-to'][0]['properties']['photo'][0])
+    assert_equal('/photo.jpg', result['items'][5]['properties']['in-reply-to'][0]['value'])
+    assert_false('alt' in result['items'][5]['properties']['in-reply-to'][0])
+
+    assert_true('h-cite' in exp_result['items'][5]['properties']['in-reply-to'][0]['type'])
+    assert_equal('/photo.jpg', exp_result['items'][5]['properties']['in-reply-to'][0]['properties']['photo'][0]['value'])
+    assert_equal('/photo.jpg', exp_result['items'][5]['properties']['in-reply-to'][0]['value'])
+    assert_equal('', exp_result['items'][5]['properties']['in-reply-to'][0]['properties']['photo'][0]['alt'])
+    assert_equal('', exp_result['items'][5]['properties']['in-reply-to'][0]['alt'])
 
 # unicode tests
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -431,7 +431,7 @@ def test_nested_values():
 def test_implied_name():
     result = parse_fixture("implied_properties/implied_properties.html")
 
-    for i in range(6):
+    for i in range(7):
         assert_equal(result["items"][i]["properties"]["name"][0], "Tom Morris")
 
 
@@ -474,8 +474,12 @@ def test_implied_nested_photo():
     result = parse_fixture("implied_properties/implied_properties.html", url="http://bar.org")
     assert_equal(result["items"][2]["properties"]["photo"][0],
                  "http://tommorris.org/photo.png")
+    assert_equal(result["items"][3]["properties"]["photo"][0],
+                 "http://tommorris.org/photo.png")
+    assert_equal(result["items"][4]["properties"]["photo"][0],
+                 "http://tommorris.org/photo.png")
     # src="" is relative to the base url
-    assert_equal(result["items"][5]["properties"]["photo"][0],
+    assert_equal(result["items"][6]["properties"]["photo"][0],
                  "http://bar.org")
 
 


### PR DESCRIPTION
Changes as in the changelog

- streamline backcompat to use JSON only.
- fix multiple mf1 root rel-tag parsing 
- correct url and photo for hreview.
- add rules for nested hreview. update backcompat to use multiple matches in old properties.
- fix `rel-tag` to `p-category` conversion so that other classes are not lost.
- use original authored html for `e-*` parsing in backcompat
- make classes and rels into unordered (alphabetically ordered) deduped arrays.
- only use class names for mf2 which follow the naming rules
- fix `parse` method to use default html parser.
- always use the first value for attributes for rels.
- correct AM/PM conversion in datetime value class pattern.
 - add ordinal date parsing to datetimes value class pattern. ordinal date is normalised to YYYY-MM-DD
- remove hack for html tag classes since that is fixed in new BS
- better whitespace algorithm for `name` and `html.value` parsing
- experimental flag for including `alt` in `u-photo` parsing
- make a copy of the BeautifulSoup given by user to work on for parsing to prevent changes to original doc
- bump version to 1.1.1 

fixes #105 #104 #101 #100 #83  