### PR TITLE
Fix #108: replace copy.deepcopy

### DIFF
--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -170,3 +170,29 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
             count = 0
 
     return text
+
+def deepcopy_tag(tag):
+    """Create deep copy of a Tag element:
+
+    Args:
+      tag (bs4.element.Tag): a Tag to copy
+
+    Returns:
+      bs4.element.Tag: a unconnected copy of tag"""
+
+    # This function is based on Tag.__copy__() in BS4,
+    # also under MIT license,  Copyright (c) 2004-2016 Leonard Richardson
+    # It only exists as a workaround since the source function is missing a deepcopy
+    # and potentially can be removed in the future
+    
+    clone = type(tag)(None, tag.builder, tag.name, tag.namespace,
+                           tag.prefix, copy.deepcopy(tag.attrs), is_xml=tag._is_xml)
+    
+    for attr in ('can_be_empty_element', 'hidden'):
+        setattr(clone, attr, getattr(tag, attr))
+        
+    for child in tag.contents:
+        clone.append(deepcopy_tag(child))
+        
+    return clone
+

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -7,7 +7,7 @@ from bs4.element import Tag
 from . import backcompat, mf2_classes, implied_properties, parse_property
 from . import temp_fixes
 from .version import __version__
-from .dom_helpers import get_attr, get_children, get_descendents
+from .dom_helpers import get_attr, get_children, get_descendents, deepcopy_tag
 from .mf_helpers import unordered_list
 
 import json
@@ -106,10 +106,12 @@ class Parser(object):
 
         if doc is not None:
             self.__doc__ = doc
-            if isinstance(doc, BeautifulSoup) or isinstance(doc, Tag):
-                # make a deepcopy of the doc to not change original; also copy the HTML builder
-                self.__doc__ = copy.deepcopy(doc)
-                self.__doc__.builder = doc.builder
+            if isinstance(doc, BeautifulSoup):
+                # make a copy of the doc to not change original;
+                #this safely regenerates all children too, but is inefficient (serializes and parses again(
+                self.__doc__ = copy.copy(doc)
+            elif isinstance(doc, Tag):
+                self.__doc__ = deepcopy_tag(doc)
             else:
                 try:
                     # try the user-given html parser or default html5lib


### PR DESCRIPTION
copy.deepcopy isn't implemented for BeautifulSoup elements.
copy.copy is, but does not properly copy attributes for Tags, it's thus replaced with a custom function.