### PR TITLE
whitespace handling: don't collapse whitespace between tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .eggs/
 build/
 dist/
+local/
 mf2py.egg-info/
 nbproject/
 venv/

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -4,6 +4,7 @@ import sys
 import bs4
 import copy
 import re
+import string
 
 from bs4.element import Tag, NavigableString, Comment
 
@@ -77,6 +78,8 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
     PRE_TAGS = ('pre',)
     P_BREAK_BEFORE = 1
     P_BREAK_AFTER = 0
+    PRE_BEFORE = 2
+    PRE_AFTER = 3
 
     def text_collection(el, replace_img=False, img_to_src=True, base_url=''):
         # returns array of strings or integers
@@ -93,13 +96,11 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
             value = re.sub(r'\t|\n|\r', ' ', value)
             # replace multiple spaces with one space
             value = re.sub(r'[ ]{1,}', ' ', value)
-
-            value = value.strip() or value
             items = [value]
 
         # don't do anything special for PRE-formatted tags defined above
         elif el.name in PRE_TAGS:
-            items = [el.get_text()]
+            items = [PRE_BEFORE, el.get_text(), PRE_AFTER]
 
         elif el.name == 'img' and replace_img:
             value = el.get('alt')
@@ -130,43 +131,58 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
     results = [t for t in text_collection(el, replace_img, img_to_src, base_url) if t is not '']
 
     if results:
-        # remove <space> if it is first and last or if it is preceded by a <space> or <int> or followed by a <int>
+        # remove <space> if it is first and last or if it is preceded by a <space> or <p> open/close
         # done by replacing it with 0
         length = len(results)
-        for i  in range(0, length):
+        for i in range(0, length):
             if (results[i] == ' ' and
                     (i == 0 or
                     i == length - 1 or
                     results[i-1] == ' ' or
-                    isinstance(results[i-1], int) or
+                    results[i-1] in (P_BREAK_BEFORE, P_BREAK_AFTER) or
                     results[i+1] == ' ' or
-                    isinstance(results[i+1], int)
+                    results[i+1] in (P_BREAK_BEFORE, P_BREAK_AFTER)
                     )
                 ):
                 results[i] = 0
 
     if results:
-        # remove leading \n and <int> i.e. next lines
-        while results[0] == '\n' or isinstance(results[0], int):
+        # remove leading whitespace and <int> i.e. next lines
+        while ((isinstance(results[0], basestring) and re.match(r'^\s+$', results[0])) or
+               results[0] in (P_BREAK_BEFORE, P_BREAK_AFTER)):
             results.pop(0)
             if not results:
                 break
+
     if results:
-        # remove trailing \n and <int> i.e. next lines
-        while results[-1] == '\n' or isinstance(results[-1], int):
+        # remove trailing whitespace and <int> i.e. next lines
+        while ((isinstance(results[-1], basestring) and re.match(r'^\s+$', results[-1])) or
+               results[-1] in (P_BREAK_BEFORE, P_BREAK_AFTER)):
             results.pop(-1)
             if not results:
                 break
 
+    # trim leading and trailing non-<pre> whitespace
+    if results:
+        if isinstance(results[0], basestring):
+            results[0] = results[0].lstrip()
+        if isinstance(results[-1], basestring):
+            results[-1] = results[-1].rstrip()
 
     # create final string by concatenating replacing consecutive sequence of <int> by largest value number of \n
     text = ''
     count = 0
+    last = None
     for t in results:
-        if isinstance(t, int):
+        if t in (P_BREAK_BEFORE, P_BREAK_AFTER):
             count = max(t, count)
-        else:
+        elif t == PRE_BEFORE:
+            text = text.rstrip(' ')
+        elif not isinstance(t, int):
+            if count or last == '\n':
+                t = t.lstrip(' ')
             text = ''.join([text, '\n'*count , t])
             count = 0
+        last = t
 
     return text

--- a/test/examples/tag_whitespace_inside_p_value.html
+++ b/test/examples/tag_whitespace_inside_p_value.html
@@ -1,0 +1,3 @@
+<article class="h-entry">
+  <div class="p-name">foo <span>bar</span></div>
+</article>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -769,6 +769,15 @@ def test_backcompat_hentry_content_html():
 
     assert_equal('<p class="entry-summary">This is a summary</p> \n        <p>This is <a href="/tags/mytag" rel="tag">mytag</a> inside content. </p>', entry['properties']['content'][0]['html'])
 
+def test_whitespace_with_tags_inside_property():
+    """Whitespace should only be trimmed at the ends of textContent, not inside.
+
+    https://github.com/microformats/mf2py/issues/112
+    """
+    result = parse_fixture('tag_whitespace_inside_p_value.html')
+    assert_equal(result['items'][0]['properties'],
+                 {'name': ['foo bar']})
+
 
 # experimental features tests
 


### PR DESCRIPTION
fixes #112. lots of background discussion there.

largely inspired by https://wiki.zegnat.net/media/textparsing.html (but not completely; more details in #112)

this is not at all pretty, and i'm open to ideas, although i'd end up refactoring much more of `get_textContent()` in the process. it passes all mf2py and granary tests though, which counts for something.