### PR TITLE
don't collapse multiple space elements in a row

### DIFF
--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -132,7 +132,6 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
 
     if results:
         # remove <space> if it is first and last or if it is preceded by a <space> or <p> open/close
-        # done by replacing it with 0
         length = len(results)
         for i in range(0, length):
             if (results[i] == ' ' and
@@ -144,11 +143,11 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
                     results[i+1] in (P_BREAK_BEFORE, P_BREAK_AFTER)
                     )
                 ):
-                results[i] = 0
+                results[i] = ''
 
     if results:
         # remove leading whitespace and <int> i.e. next lines
-        while ((isinstance(results[0], basestring) and re.match(r'^\s+$', results[0])) or
+        while ((isinstance(results[0], basestring) and re.match(r'^\s*$', results[0])) or
                results[0] in (P_BREAK_BEFORE, P_BREAK_AFTER)):
             results.pop(0)
             if not results:
@@ -156,7 +155,7 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
 
     if results:
         # remove trailing whitespace and <int> i.e. next lines
-        while ((isinstance(results[-1], basestring) and re.match(r'^\s+$', results[-1])) or
+        while ((isinstance(results[-1], basestring) and re.match(r'^\s*$', results[-1])) or
                results[-1] in (P_BREAK_BEFORE, P_BREAK_AFTER)):
             results.pop(-1)
             if not results:

--- a/test/examples/implied_properties/implied_name_alt.html
+++ b/test/examples/implied_properties/implied_name_alt.html
@@ -1,0 +1,5 @@
+<article class="h-entry">
+  <div class="author h-card">
+    <img alt="Avatar of" class="u-photo" src="avatar.jpg" /> <span>Stephen</span>
+  </div>
+</article>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -567,6 +567,14 @@ def test_simple_person_reference_implied():
                  {'name': ['Frances Berriman']})
 
 
+def test_implied_name_alt():
+    result = parse_fixture("implied_properties/implied_name_alt.html")
+    assert_equal(result["items"][0]["children"][0],
+                 {'type': ['h-card'],
+                  'properties': {'name': ['Avatar of Stephen'],
+                                 'photo': ['avatar.jpg']}})
+
+
 def test_value_name_whitespace():
     result = parse_fixture("value_name_whitespace.html")
 


### PR DESCRIPTION
...e.g. from img alt text next to a single space. (was happening with other elements too.)

cc @kartikprabhu. the PR here is just the last commit. the others will disappear as soon as #115 is approved and merged.