### PR TITLE
Performance improvements: reduce and optimize regular expressions

### DIFF
--- a/mf2py/backcompat.py
+++ b/mf2py/backcompat.py
@@ -68,9 +68,10 @@ def _make_classes_rule(old_classes, new_classes):
             child['class'] = child_classes
 
             # if any new class is e-* attach original to parse originally authored HTML
-            if mf2_classes.embedded(child_classes) and child.original is None:
+            if mf2_classes.has_embedded_class(child_classes) and child.original is None:
                 child.original = child_original
     return f
+
 
 def _rel_tag_to_category_rule(child, html_parser, **kwargs):
     """rel=tag converts to p-category using a special transformation (the
@@ -147,8 +148,7 @@ def apply_rules(el, html_parser):
         for child in get_children(parent):
             classes = child.get('class',[])[:]
             # find existing mf2 properties if any and delete them
-            mf2_props = mf2_classes.property_classes(classes)
-            child['class'] = [cl for cl in classes if cl not in mf2_props]
+            child['class'] = [cl for cl in classes if not mf2_classes.is_property_class(cl)]
 
             # apply rules to change mf1 to mf2
             for rule in rules:
@@ -157,7 +157,6 @@ def apply_rules(el, html_parser):
             # recurse if it's not a nested mf1 or mf2 root
             if not (mf2_classes.root(classes) or root(classes)):
                 apply_prop_rules_to_children(child, rules)
-
 
     # add mf2 root equivalent
     classes = el_copy.get('class', [])[:]

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -147,7 +147,7 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
 
     if results:
         # remove leading whitespace and <int> i.e. next lines
-        while ((isinstance(results[0], basestring) and re.match(r'^\s*$', results[0])) or
+        while ((isinstance(results[0], basestring) and (results[0] == '' or results[0].isspace())) or
                results[0] in (P_BREAK_BEFORE, P_BREAK_AFTER)):
             results.pop(0)
             if not results:
@@ -155,7 +155,7 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
 
     if results:
         # remove trailing whitespace and <int> i.e. next lines
-        while ((isinstance(results[-1], basestring) and re.match(r'^\s*$', results[-1])) or
+        while ((isinstance(results[-1], basestring) and (results[-1] == '' or results[-1].isspace())) or
                results[-1] in (P_BREAK_BEFORE, P_BREAK_AFTER)):
             results.pop(-1)
             if not results:

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -18,6 +18,10 @@ else:
     binary_type = bytes
     basestring = str
 
+
+_whitespace_to_space_regex = re.compile(r"[\n\t\r]+")
+_reduce_spaces_regex = re.compile(r" {2,}")
+
 def get_attr(el, attr, check_name=None):
     """Get the attribute of an element if it exists.
 
@@ -93,10 +97,9 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
         elif isinstance(el, NavigableString):
             value = text_type(el)
             # replace \t \n \r by space
-            value = re.sub(r'\t|\n|\r', ' ', value)
+            value = _whitespace_to_space_regex.sub(' ', value)
             # replace multiple spaces with one space
-            value = re.sub(r'[ ]{1,}', ' ', value)
-            items = [value]
+            items = [_reduce_spaces_regex.sub(' ', value)]
 
         # don't do anything special for PRE-formatted tags defined above
         elif el.name in PRE_TAGS:

--- a/mf2py/mf2_classes.py
+++ b/mf2py/mf2_classes.py
@@ -15,12 +15,12 @@ def filter_classes(classes, regex=_mf2_classes_re):
 
     types = {x: set() for x in ('u', 'p', 'dt', 'e', 'h')}
     for c in classes:
-        a=regex.match(c)
-        if a:
+        match = regex.match(c)
+        if match:
             if c[0] == "h":
                 types['h'].add(c)
             else:
-                types[a[1]].add(a[2])
+                types[match.group(1)].add(match.group(2))
     return types
 
 

--- a/mf2py/mf2_classes.py
+++ b/mf2py/mf2_classes.py
@@ -4,58 +4,31 @@ from .mf_helpers import unordered_list
 
 import re
 
-def _check_format(prefix, cl):
+_mf2_classes_re = re.compile("(p|e|u|dt|h)-((:?[a-z0-9]+-)?[a-z]+(:?-[a-z]+)*)$")
+_mf2_roots_re = re.compile("h-(:?[a-z0-9]+-)?[a-z]+(:?-[a-z]+)*$")
+_mf2_properties_re = re.compile("(p|e|u|dt)-(:?[a-z0-9]+-)?[a-z]+(:?-[a-z]+)*$")
+_mf2_e_properties_re = re.compile("e-(:?[a-z0-9]+-)?[a-z]+(:?-[a-z]+)*$")
 
-    # older one does not check hyphens
-    #FORMAT_RE = r'%s-([a-z0-9]+-)?[a-z-]+'
 
-    FORMAT_RE = r'%s-([a-z0-9]+-)?[a-z]+(-[a-z]+)*'
+def filter_classes(classes, regex=_mf2_classes_re):
+    """detect classes that are valid names for mf2, sort in dictionary by prefix"""
 
-    RE = FORMAT_RE % (prefix)
+    types = {x: set() for x in ('u', 'p', 'dt', 'e', 'h')}
+    for c in classes:
+        a=regex.match(c)
+        if a:
+            if c[0] == "h":
+                types['h'].add(c)
+            else:
+                types[a[1]].add(a[2])
+    return types
 
-    return re.match(RE + '$', cl)
 
 def root(classes):
-    """get all root classnames
-    """
+    return {c for c in classes if _mf2_roots_re.match(c)}
 
-    return unordered_list([c for c in classes if _check_format('h', c)])
+def is_property_class(class_):
+    return _mf2_properties_re.match(class_)
 
-
-def properties(classes):
-    """get all property (p-*, u-*, e-*, dt-*) classnames
-    """
-
-    return unordered_list([c.partition("-")[2] for c in classes if _check_format('(p|u|dt|e)', c)])
-
-def property_classes(classes):
-    """get all property (p-*, u-*, e-*, dt-*) classnames with prefix
-    """
-
-    return unordered_list([c for c in classes if _check_format('(p|u|dt|e)', c)])
-
-def text(classes):
-    """get text property (p-*) names
-    """
-
-    return unordered_list([c.partition("-")[2] for c in classes if _check_format('p', c)])
-
-
-def url(classes):
-    """get URL property (u-*) names
-    """
-
-    return unordered_list([c.partition("-")[2] for c in classes if _check_format('u', c)])
-
-
-def datetime(classes):
-    """get datetime property (dt-*) names
-    """
-
-    return unordered_list([c.partition("-")[2] for c in classes if _check_format('dt', c)])
-
-def embedded(classes):
-    """get embedded property (e-*) names
-    """
-
-    return unordered_list([c.partition("-")[2] for c in classes if _check_format('e', c)])
+def has_embedded_class(classes):
+    return any(_mf2_e_properties_re.match(c) for c in classes)

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -169,7 +169,7 @@ class Parser(object):
 
             if backcompat_mode:
                 el = backcompat.apply_rules(el, self.__html_parser__)
-                root_class_names = mf2_classes.root(el.get('class',[]))
+                root_class_names = mf2_classes.root(el.get('class', []))
 
             # parse for properties and children
             for child in get_children(el):
@@ -206,7 +206,7 @@ class Parser(object):
             # build microformat with type and properties
             microformat = self.dict_class([
                 ("type", [text_type(class_name)
-                          for class_name in root_class_names]),
+                          for class_name in sorted(root_class_names)]),
                 ("properties", properties),
             ])
             if str(el.name) == "area":
@@ -244,8 +244,9 @@ class Parser(object):
             parsed_types_aggregation = set()
 
             classes = el.get("class", [])
+            filtered_classes = mf2_classes.filter_classes(classes)
             # Is this element a microformat2 root?
-            root_class_names = mf2_classes.root(classes)
+            root_class_names = filtered_classes['h']
             backcompat_mode = False
 
             # Is this element a microformat1 root?
@@ -262,7 +263,7 @@ class Parser(object):
 
             # Parse plaintext p-* properties.
             p_value = None
-            for prop_name in mf2_classes.text(classes):
+            for prop_name in filtered_classes['p']:
                 is_property_el = True
                 parsed_types_aggregation.add('p')
                 prop_value = props.setdefault(prop_name, [])
@@ -280,7 +281,7 @@ class Parser(object):
 
             # Parse URL u-* properties.
             u_value = None
-            for prop_name in mf2_classes.url(classes):
+            for prop_name in filtered_classes['u']:
                 is_property_el = True
                 parsed_types_aggregation.add('u')
                 prop_value = props.setdefault(prop_name, [])
@@ -301,7 +302,7 @@ class Parser(object):
 
             # Parse datetime dt-* properties.
             dt_value = None
-            for prop_name in mf2_classes.datetime(classes):
+            for prop_name in filtered_classes['dt']:
                 is_property_el = True
                 parsed_types_aggregation.add('d')
                 prop_value = props.setdefault(prop_name, [])
@@ -325,7 +326,7 @@ class Parser(object):
 
             # Parse embedded markup e-* properties.
             e_value = None
-            for prop_name in mf2_classes.embedded(classes):
+            for prop_name in filtered_classes['e']:
                 is_property_el = True
                 parsed_types_aggregation.add('e')
                 prop_value = props.setdefault(prop_name, [])


### PR DESCRIPTION
Testing against cleverdevils massive feed, this improves the mf2-parsing stage (so excluding HTML parsing) of parsing cleverdevils large feed file by around 20 %, from ~1s to ~0.8s

The number of iterations over class lists is reduced, regular expressions are pre-compiled and combined into larger ones.