### PR TITLE
Catch ValueError from urljoin, pass through broken value instead

### DIFF
--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -22,6 +22,16 @@ else:
 _whitespace_to_space_regex = re.compile(r"[\n\t\r]+")
 _reduce_spaces_regex = re.compile(r" {2,}")
 
+
+def try_urljoin(base, url, allow_fragments=True):
+    """attempts urljoin, on ValueError passes through url"""
+    try:
+        url = urljoin(base, url, allow_fragments=allow_fragments)
+    except ValueError:
+        pass
+    return url
+
+
 def get_attr(el, attr, check_name=None):
     """Get the attribute of an element if it exists.
 
@@ -51,7 +61,7 @@ def get_img_src_alt(img, dict_class, img_with_alt, base_url=''):
     src = get_attr(img, "src", check_name="img")
 
     if src is not None:
-        src = urljoin(base_url, src)
+        src = try_urljoin(base_url, src)
 
         if alt is None or not img_with_alt:
             return text_type(src)
@@ -110,7 +120,7 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
             if value is None and img_to_src:
                 value = el.get('src')
                 if value is not None:
-                    value = urljoin(base_url, value)
+                    value = try_urljoin(base_url, value)
 
             if value is not None:
                 items = [' ', text_type(value), ' ']

--- a/mf2py/implied_properties.py
+++ b/mf2py/implied_properties.py
@@ -1,14 +1,12 @@
 from __future__ import unicode_literals, print_function
 from . import mf2_classes
-from .dom_helpers import get_attr, get_img_src_alt, get_children, get_textContent
+from .dom_helpers import get_attr, get_img_src_alt, get_children, get_textContent, try_urljoin
 import sys
 
 if sys.version < '3':
-    from urlparse import urljoin
     text_type = unicode
     binary_type = str
 else:
-    from urllib.parse import urljoin
     text_type = str
     binary_type = bytes
 
@@ -174,7 +172,7 @@ def url(el, base_url=''):
     # if element is a <a> or area use its href if exists
     prop_value = get_attr(el, "href", check_name=("a", "area"))
     if prop_value is not None:  # an empty href is valid
-        return text_type(urljoin(base_url, prop_value))
+        return text_type(try_urljoin(base_url, prop_value))
 
     # find candidate child or grandchild
     poss_child = None
@@ -192,4 +190,4 @@ def url(el, base_url=''):
     if poss_child is not None:
         prop_value = get_attr(poss_child, "href", check_name=("a", "area"))
         if prop_value is not None:  # an empty href is valid
-            return text_type(urljoin(base_url, prop_value))
+            return text_type(try_urljoin(base_url, prop_value))

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -1,7 +1,7 @@
 """functions to parse the properties of elements"""
 from __future__ import unicode_literals, print_function
 
-from .dom_helpers import get_attr, get_img_src_alt, get_children, get_textContent
+from .dom_helpers import get_attr, get_img_src_alt, get_children, get_textContent, try_urljoin
 from .datetime_helpers import normalize_datetime, DATETIME_RE, TIME_RE
 from . import value_class_pattern
 
@@ -9,11 +9,9 @@ import sys
 import re
 
 if sys.version < '3':
-    from urlparse import urljoin
     text_type = unicode
     binary_type = str
 else:
-    from urllib.parse import urljoin
     text_type = str
     binary_type = bytes
 
@@ -52,7 +50,7 @@ def url(el, dict_class, img_with_alt, base_url=''):
         prop_value = get_attr(el, "data", check_name="object")
 
     if prop_value is not None:
-        return urljoin(base_url, prop_value)
+        return try_urljoin(base_url, prop_value)
 
     # handle value-class-pattern
     prop_value = value_class_pattern.text(el)

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -7,7 +7,7 @@ from bs4.element import Tag
 from . import backcompat, mf2_classes, implied_properties, parse_property
 from . import temp_fixes
 from .version import __version__
-from .dom_helpers import get_attr, get_children, get_descendents
+from .dom_helpers import get_attr, get_children, get_descendents, try_urljoin
 from .mf_helpers import unordered_list
 
 import json
@@ -16,11 +16,11 @@ import sys
 import copy
 
 if sys.version < '3':
-    from urlparse import urlparse, urljoin
+    from urlparse import urlparse
     text_type = unicode
     binary_type = str
 else:
-    from urllib.parse import urlparse, urljoin
+    from urllib.parse import urlparse
     text_type = str
     binary_type = bytes
 
@@ -139,7 +139,7 @@ class Parser(object):
                         self.__url__ = poss_base_url
                     elif self.__url__:
                         # base specifies a relative path
-                        self.__url__ = urljoin(self.__url__, poss_base_url)
+                        self.__url__ = try_urljoin(self.__url__, poss_base_url)
 
         if self.__doc__ is not None:
             # parse!
@@ -373,7 +373,7 @@ class Parser(object):
             # if rel attributes exist
             if rel_attrs is not None:
                 # find the url and normalise it
-                url = text_type(urljoin(self.__url__, el.get('href', '')))
+                url = try_urljoin(self.__url__, el.get('href', ''))
                 value_dict = self.__parsed__["rel-urls"].get(url,
                                                              self.dict_class())
 

--- a/test/examples/broken_url.html
+++ b/test/examples/broken_url.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <title>Hello World</title>
+</head>
+<body>
+<article class="h-entry">
+    <h1><a  class="p-name">urls with broken domains</a></h1>
+    <a class="u-url" href="http://www.[w3.org/">Should not change: http://www.[w3.org/</a>
+    <a class="u-relative" href="foo.html">Should be relative to base url</a>
+    <img src="http://www.w3].org/20[08/site/images/logo-w3c-mobile-lg" class="u-photo">
+</article>
+</body>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -368,6 +368,11 @@ def test_link_with_u_url():
         },
     }, result["items"][0])
 
+def test_broken_url():
+    result = parse_fixture("broken_url.html", "http://example.com")
+    assert_equal(result["items"][0]["properties"]["relative"][0], "http://example.com/foo.html")
+    assert_equal(result["items"][0]["properties"]["url"][0], "http://www.[w3.org/")
+    assert_equal(result["items"][0]["properties"]["photo"][0], "http://www.w3].org/20[08/site/images/logo-w3c-mobile-lg")
 
 def test_complex_e_content():
     """When parsing h-* e-* properties, we should fold {"value":..., "html":...}


### PR DESCRIPTION
Fixes #79 by passing through the values as they are, since https://github.com/microformats/microformats2-parsing/issues/9 didn't lead to any other suggestion.