### PR TITLE
longitude/latitude was removed from hentry backcompat 

### DIFF
--- a/mf2py/backcompat-rules/hentry.json
+++ b/mf2py/backcompat-rules/hentry.json
@@ -11,10 +11,7 @@
         ], 
         "published": [
             "dt-published"
-        ], 
-        "latitude": [
-            "p-latitude"
-        ], 
+        ],
         "entry-content": [
             "e-content"
         ], 
@@ -31,9 +28,6 @@
         ], 
         "updated": [
             "dt-updated"
-        ], 
-        "longitude": [
-            "p-longitude"
         ]
     },
     "rels": {


### PR DESCRIPTION
quite a while ago: http://microformats.org/wiki/index.php?title=h-entry&diff=next&oldid=60791