### PR TITLE
Fix 127

### DIFF
--- a/mf2py/backcompat-rules/hentry.json
+++ b/mf2py/backcompat-rules/hentry.json
@@ -19,13 +19,12 @@
             "p-summary"
         ], 
         "author": [
-            "p-author", 
-            "h-card"
-        ], 
+            "p-author",
+            "vcard"
+        ],
         "geo": [
-            "p-geo", 
-            "h-geo"
-        ], 
+            "p-geo"
+        ],
         "updated": [
             "dt-updated"
         ]

--- a/mf2py/backcompat-rules/hentry.json
+++ b/mf2py/backcompat-rules/hentry.json
@@ -11,10 +11,7 @@
         ], 
         "published": [
             "dt-published"
-        ], 
-        "latitude": [
-            "p-latitude"
-        ], 
+        ],
         "entry-content": [
             "e-content"
         ], 
@@ -31,9 +28,6 @@
         ], 
         "updated": [
             "dt-updated"
-        ], 
-        "longitude": [
-            "p-longitude"
         ]
     },
     "rels": {

--- a/mf2py/backcompat-rules/hproduct.json
+++ b/mf2py/backcompat-rules/hproduct.json
@@ -26,7 +26,7 @@
         ], 
         "review": [
             "p-review", 
-            "h-review" 
+            "hreview"
         ], 
         "fn": [
             "p-name"

--- a/mf2py/backcompat-rules/hresume.json
+++ b/mf2py/backcompat-rules/hresume.json
@@ -4,26 +4,26 @@
     ], 
     "properties": {
         "experience": [
-            "h-event", 
-            "p-experience"
+            "p-experience",
+            "vevent"
         ], 
         "summary": [
             "p-summary"
         ], 
         "affiliation": [
             "p-affiliation", 
-            "h-card"
+            "vcard"
         ], 
         "contact": [
-            "h-card", 
-            "p-contact"
+            "p-contact",
+            "vcard"
         ], 
         "skill": [
             "p-skill"
         ], 
         "education": [
-            "h-event", 
-            "p-education"
+            "p-education",
+            "vevent"
         ]
     }
 }

--- a/mf2py/backcompat-rules/hreview-aggregate.json
+++ b/mf2py/backcompat-rules/hreview-aggregate.json
@@ -18,7 +18,7 @@
         "reviewer": [
             "p-reviewer", 
             "p-author", 
-            "h-card"
+            "vcard"
         ], 
         "best": [
             "p-best"

--- a/mf2py/backcompat-rules/hreview.json
+++ b/mf2py/backcompat-rules/hreview.json
@@ -14,11 +14,11 @@
         ], 
         "reviewer": [
             "p-author", 
-            "h-card"
+            "vcard"
         ], 
         "url": [
             "p-item", 
-            "h-item", 
+            "h-item",
             "u-url"
         ], 
         "photo": [

--- a/mf2py/backcompat-rules/vcard.json
+++ b/mf2py/backcompat-rules/vcard.json
@@ -31,8 +31,7 @@
             "p-category"
         ], 
         "adr": [
-            "p-adr", 
-            "h-adr"
+            "p-adr"
         ], 
         "locality": [
             "p-locality"
@@ -80,8 +79,7 @@
             "p-honorific-prefix"
         ], 
         "geo": [
-            "p-geo", 
-            "h-geo"
+            "p-geo"
         ], 
         "fn": [
             "p-name"

--- a/mf2py/backcompat-rules/vevent.json
+++ b/mf2py/backcompat-rules/vevent.json
@@ -19,7 +19,7 @@
             "dt-start"
         ], 
         "geo": [
-            "p-location h-geo"
+            "p-location"
         ], 
         "organizer": [
             "p-organizer"

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -606,9 +606,10 @@ def test_value_name_whitespace():
 def test_backcompat_hentry():
     result = parse_fixture("backcompat/hentry.html")
     assert_true('h-entry' in result['items'][0]['type'])
+    assert_equal({},
+                 result['items'][0]['properties']['author'][0]['properties'])
     assert_equal('Tom Morris',
-                 result['items'][0]['properties']
-                 ['author'][0]['properties']['name'][0])
+                 result['items'][0]['properties']['author'][0]['value'])
     assert_equal('A Title',
                  result['items'][0]['properties']['name'][0])
     assert_equal('Some Content',


### PR DESCRIPTION
Adjusts the root classes added to mf1 roots, to properly cause backcompat instead of mf2 parsing for nested objects.