### PR TITLE
VCP now handles tz offsets without leading zeros

### DIFF
--- a/mf2py/datetime_helpers.py
+++ b/mf2py/datetime_helpers.py
@@ -10,7 +10,7 @@ DATE_RE = r'(\d{4}-\d{2}-\d{2})|(\d{4}-\d{3})'
 SEC_RE = r'(:(?P<second>\d{2})(\.\d+)?)'
 RAWTIME_RE = r'(?P<hour>\d{1,2})(:(?P<minute>\d{2})%s?)?' % (SEC_RE)
 AMPM_RE = r'am|pm|a\.m\.|p\.m\.|AM|PM|A\.M\.|P\.M\.'
-TIMEZONE_RE = r'Z|[+-]\d{2}:?\d{2}?'
+TIMEZONE_RE = r'Z|[+-]\d{1,2}:?\d{2}?'
 TIME_RE = (r'(?P<rawtime>%s)( ?(?P<ampm>%s))?( ?(?P<tz>%s))?' %
            (RAWTIME_RE, AMPM_RE, TIMEZONE_RE))
 DATETIME_RE = (r'(?P<date>%s)(?P<separator>[T ])(?P<time>%s)'

--- a/test/examples/datetimes.html
+++ b/test/examples/datetimes.html
@@ -140,5 +140,38 @@
    </p>
  </div>
 
+ <div class="h-entry">
+   <!-- wiki event with UTC offset without leading zero -->
+   <span class="dt-start">
+     <span class="value" title="June 1, 2014">2014-06-01</span>
+     <span class="value" title="12:30">12:30<span style="display: none;">-6:00</span></span>
+   </span>
+ </div>
+
+ <div class="h-entry">
+   <!-- wiki event with positive UTC offset without leading zero-->
+   <span class="dt-start">
+     <span class="value" title="June 1, 2014">2014-06-01</span>
+     <span class="value" title="12:30">12:30<span style="display: none;">+6:00</span></span>
+   </span>
+ </div>
+
+<div class="h-entry">
+   <!-- wiki event with Zulu time-->
+   <span class="dt-start">
+     <span class="value" title="June 1, 2014">2014-06-01</span>
+     <span class="value" title="12:30">12:30<span style="display: none;">Z</span></span>
+   </span>
+ </div>
+
+ <div class="h-entry">
+   <!-- with UTC offset without leading zero in extra value part -->
+   <span class="dt-start">
+     <span class="value" title="June 1, 2014">2014-06-01</span>
+     <span class="value" title="12:30">12:30</span><span class="value">-6:00</span></span>
+   </span>
+ </div>
+
+
 </body>
 </html>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -160,6 +160,7 @@ def test_datetime_parsing():
 
 def test_datetime_vcp_parsing():
     result = parse_fixture("datetimes.html")
+    assert_equal(len(result['items']), 16)
     assert_equal(result["items"][1]["properties"]["published"][0],
                  "3014-01-01 01:21Z")
     assert_equal(result["items"][2]["properties"]["updated"][0],
@@ -184,7 +185,14 @@ def test_datetime_vcp_parsing():
                  "2014-06-01 12:15")
     assert_equal(result["items"][11]["properties"]["start"][0],
                  "2016-03-02 00:30-06:00")
-
+    assert_equal(result["items"][12]["properties"]["start"][0],
+                 "2014-06-01 12:30-6:00")
+    assert_equal(result["items"][13]["properties"]["start"][0],
+                 "2014-06-01 12:30+6:00")
+    assert_equal(result["items"][14]["properties"]["start"][0],
+                 "2014-06-01 12:30Z")
+    assert_equal(result["items"][15]["properties"]["start"][0],
+                 "2014-06-01 12:30-6:00")
 def test_dt_end_implied_date():
     """Test that events with dt-start and dt-end use the implied date rule
     http://microformats.org/wiki/value-class-pattern#microformats2_parsers


### PR DESCRIPTION
As pointed out by @aaronpk today, mf2py didn't cover correctly that timezone offsets do not need to have a leading zero.

VCP documentation explicitly says
>  XX is the time zone hours offset, from 00 to 12 with optional leading 0 for values less than 10. 