### PR TITLE
Update CI setup to install libxml2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,14 @@ jobs:
   build:
     strategy:
       matrix:
-        python_version: ["2.7", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "pypy2", "pypy3"]
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-    runs-on: ${{ matrix.os }}
+        python_version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install libxml2
+        run: |
+          sudo apt-get update
+          sudo apt-get install libxml2 libxml2-dev libxslt1-dev
       - name: Install Python
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
Unfortunately, this means temporarily dropping multi-OS testing for now. May bring back the Mac testing at some point, and if there's demand, we can start doing Windows testing again when there's a sensible way to get libxml2 on Windows in CI.