### PR TITLE
Update lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 html5lib==1.0.1
 nose==1.3.7
 mock==2.0.0
-lxml==4.2.5
+lxml==4.6.5
 requests==2.21.0
 BeautifulSoup4==4.6.3
 -e .


### PR DESCRIPTION
Until we have a new build tool, at the very least, we should have a newer lxml without the vulnerabilities in older versions.

https://github.com/advisories/GHSA-55x5-fj6c-h6m8