### PR TITLE
Enable img_with_alt by default

### DIFF
--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -69,7 +69,7 @@ class Parser(object):
 
     dict_class = dict
 
-    def __init__(self, doc=None, url=None, html_parser=None, img_with_alt=False):
+    def __init__(self, doc=None, url=None, html_parser=None, img_with_alt=True):
         self.__url__ = None
         self.__doc__ = None
         self._preserve_doc = False


### PR DESCRIPTION
This PR enables the `img_with_alt` flag by default on parser invocations.