### PR TITLE
Prepare release for 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 1.1.3 - 2022-02-
+- reduce instances where photo is implied (#135)
+- always do relative URL resolution (#138)
+- VCP now handles tz offsets without leading zeros (#142)
+- implement id parsing (#143)
+- fix outdated syntax causing SyntaxWarning (#157)
+
 ## 1.1.2 - 2018-08-08
 - add parsing for iframe.u-*[src] (#116)
 - bug fix: reduced implied urls (#117)

--- a/mf2py/version.py
+++ b/mf2py/version.py
@@ -1,4 +1,4 @@
 # Define the version number. This class is exec'd by setup.py to read
 # the value without loading mf2py (loading mf2py is bad if its dependencies
 # haven't been installed yet, which is common during setup)
-__version__ = '1.1.2'
+__version__ = '1.1.3'

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(name='mf2py',
       author='Tom Morris',
       author_email='tom@tommorris.org',
       url='http://microformats.org/wiki/mf2py',
+      python_requires='>=2.7',
       install_requires=[
           # Keep in sync with requirements.txt!
           'html5lib>=1.0.1',


### PR DESCRIPTION
Release five fixes/features along with a setup.py `python_requires` version specifier in anticipation of python2 deprecation. See https://github.com/microformats/mf2py/issues/87#issuecomment-1610297218