### PR TITLE
Make relative URLs in `e-` properties absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 2.0 - unreleased
+- make relative URLs in e-* properties absolute (#201)
+
 ## 1.1.3 - 2023-06-28
 - reduce instances where photo is implied (#135)
 - always do relative URL resolution (#138)

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -96,6 +96,10 @@ def datetime(el, default_date=None):
 
 def embedded(el, base_url=""):
     """Process e-* properties"""
+    for tag in el.find_all():
+        for attr in ("href", "src", "cite", "poster"):
+            if attr in tag.attrs:
+                tag.attrs[attr] = try_urljoin(base_url, tag.attrs[attr])
     return {
         "html": el.decode_contents().strip(),  # secret bs4 method to get innerHTML
         "value": get_textContent(el, replace_img=True, base_url=base_url),

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -97,7 +97,7 @@ def datetime(el, default_date=None):
 def embedded(el, base_url=""):
     """Process e-* properties"""
     for tag in el.find_all():
-        for attr in ("href", "src", "cite", "poster"):
+        for attr in ("href", "src", "cite", "data", "poster"):
             if attr in tag.attrs:
                 tag.attrs[attr] = try_urljoin(base_url, tag.attrs[attr])
     return {

--- a/test/examples/relative_url_in_e.html
+++ b/test/examples/relative_url_in_e.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <title>Relative URLs in e-content</title>
+  <base href="http://example.com/" />
+</head>
+<body>
+<div class="h-entry">
+<div class="e-content"><p><a href=/cat.html>Cat <img src=cat.jpg></a></p></div>
+</div>
+</body>
+</html>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -390,7 +390,7 @@ def test_complex_e_content():
 
 
 def test_relative_url_in_e():
-    """ """
+    """When parsing e-* properties, make relative URLs absolute."""
     result = parse_fixture("relative_url_in_e.html")
 
     assert (

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -389,6 +389,26 @@ def test_complex_e_content():
     } == result["items"][0]
 
 
+def test_relative_url_in_e():
+    """ """
+    result = parse_fixture("relative_url_in_e.html")
+
+    assert {
+        "type": ["h-entry"],
+        "properties": {
+            "content": [
+                {
+                    "html": (
+                        '<p><a href="http://example.com/cat.html">Cat '
+                        '<img src="http://example.com/cat.jpg"/></a></p>'
+                    ),
+                    "value": "Cat  http://example.com/cat.jpg",
+                }
+            ],
+        },
+    } == result["items"][0]
+
+
 def test_nested_values():
     """When parsing nested microformats, check that value is the value of
     the simple property element"""

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -393,20 +393,10 @@ def test_relative_url_in_e():
     """ """
     result = parse_fixture("relative_url_in_e.html")
 
-    assert {
-        "type": ["h-entry"],
-        "properties": {
-            "content": [
-                {
-                    "html": (
-                        '<p><a href="http://example.com/cat.html">Cat '
-                        '<img src="http://example.com/cat.jpg"/></a></p>'
-                    ),
-                    "value": "Cat  http://example.com/cat.jpg",
-                }
-            ],
-        },
-    } == result["items"][0]
+    assert (
+        '<p><a href="http://example.com/cat.html">Cat '
+        '<img src="http://example.com/cat.jpg"/></a></p>'
+    ) == result["items"][0]["properties"]["content"][0]["html"]
 
 
 def test_nested_values():


### PR DESCRIPTION
Closes #181.

Does not support `srcset` -- should eventually reuse logic from https://github.com/microformats/mf2py/pull/188 when ready.