### PR TITLE
Add language support

### DIFF
--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -94,9 +94,16 @@ def datetime(el, default_date=None):
     )
 
 
-def embedded(el, base_url=""):
+def embedded(el, root_lang, document_lang, base_url=""):
     """Process e-* properties"""
-    return {
+    prop_value = {
         "html": el.decode_contents().strip(),  # secret bs4 method to get innerHTML
         "value": get_textContent(el, replace_img=True, base_url=base_url),
     }
+    if lang := el.attrs.get("lang"):
+        prop_value["lang"] = lang
+    elif root_lang:
+        prop_value["lang"] = root_lang
+    elif document_lang:
+        prop_value["lang"] = document_lang
+    return prop_value

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -68,6 +68,7 @@ class Parser(object):
                 "version": __version__,
             },
         }
+        self.lang = None
 
         # use default parser if none specified
         self.__html_parser__ = html_parser or "html5lib"
@@ -129,6 +130,10 @@ class Parser(object):
 
         if self.__doc__ is not None:
             # parse!
+            # print(self.__doc__.find("html").attrs.get("lang"))
+            if root := self.__doc__.find("html"):
+                if lang := root.attrs.get("lang"):
+                    self.lang = lang
             self.parse()
 
     def parse(self):
@@ -161,13 +166,15 @@ class Parser(object):
                 el = backcompat.apply_rules(el, self.__html_parser__)
                 root_class_names = mf2_classes.root(el.get("class", []))
 
+            root_lang = el.attrs.get("lang")
+
             # parse for properties and children
             for child in get_children(el):
                 (
                     child_props,
                     child_children,
                     child_parsed_types_aggregation,
-                ) = parse_props(child)
+                ) = parse_props(child, root_lang)
                 for key, new_value in child_props.items():
                     prop_value = properties.get(key, [])
                     prop_value.extend(new_value)
@@ -239,9 +246,13 @@ class Parser(object):
                 else:
                     microformat["value"] = simple_value
 
+            if root_lang:
+                microformat["lang"] = root_lang
+            elif self.lang:
+                microformat["lang"] = self.lang
             return microformat
 
-        def parse_props(el):
+        def parse_props(el, root_lang):
             """Parse the properties from a single element"""
             props = {}
             children = []
@@ -363,7 +374,7 @@ class Parser(object):
                         embedded_el = copy.copy(embedded_el)
                     temp_fixes.rm_templates(embedded_el)
                     e_value = parse_property.embedded(
-                        embedded_el, base_url=self.__url__
+                        embedded_el, root_lang, self.lang, base_url=self.__url__
                     )
 
                 if root_class_names:
@@ -394,7 +405,7 @@ class Parser(object):
                         child_properties,
                         child_microformats,
                         child_parsed_types_aggregation,
-                    ) = parse_props(child)
+                    ) = parse_props(child, root_lang)
                     for prop_name in child_properties:
                         v = props.get(prop_name, [])
                         v.extend(child_properties[prop_name])

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -131,8 +131,7 @@ class Parser(object):
         if self.__doc__ is not None:
             # parse!
             if root := self.__doc__.find("html"):
-                if lang := root.attrs.get("lang"):
-                    self.lang = lang
+                self.lang = root.attrs.get("lang")
             self.parse()
 
     def parse(self):

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -129,9 +129,9 @@ class Parser(object):
                         self.__url__ = try_urljoin(self.__url__, poss_base_url)
 
         if self.__doc__ is not None:
+            if document := self.__doc__.find("html"):
+                self.lang = document.attrs.get("lang")
             # parse!
-            if root := self.__doc__.find("html"):
-                self.lang = root.attrs.get("lang")
             self.parse()
 
     def parse(self):

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -130,7 +130,6 @@ class Parser(object):
 
         if self.__doc__ is not None:
             # parse!
-            # print(self.__doc__.find("html").attrs.get("lang"))
             if root := self.__doc__.find("html"):
                 if lang := root.attrs.get("lang"):
                     self.lang = lang

--- a/test/examples/language.html
+++ b/test/examples/language.html
@@ -1,0 +1,15 @@
+<html lang="it">
+  <div class="h-card">
+    <h1 class="p-name">Romero</h1>
+  </div>
+  <div class="h-entry">
+    <h1 class="p-name">Un titolo italiano</h1>
+    <div class="e-content" lang="en">With an <em>english</em> summary</div>
+    <div class="e-content">Con un riassunto <em>italiano</em></div>
+  </div>
+  <div class="h-entry" lang="sv">
+    <h1 class="p-name">En svensk titel</h1>
+    <div class="e-content" lang="en">With an <em>english</em> summary</div>
+    <div class="e-content">Och <em>svensk</em> huvudtext</div>
+  </div>
+</html>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1029,3 +1029,14 @@ def test_all_u_cases():
         make_labelled_cmp("all_u_cases_" + str(i))(
             "http://example.com/test", result["items"][0]["properties"]["url"][i]
         )
+
+
+def test_language():
+    result = parse_fixture("language.html")
+    assert result["items"][0]["lang"] == "it"
+    assert result["items"][1]["lang"] == "it"
+    assert result["items"][1]["properties"]["content"][0]["lang"] == "en"
+    assert result["items"][1]["properties"]["content"][1]["lang"] == "it"
+    assert result["items"][2]["lang"] == "sv"
+    assert result["items"][2]["properties"]["content"][0]["lang"] == "en"
+    assert result["items"][2]["properties"]["content"][1]["lang"] == "sv"


### PR DESCRIPTION
Add language details to embedded properties and root microformats using the following order of specificity:

* embedded properties (`class=e-* lang=..`)
* root microformats (`class=h-* lang=..`)
* document root (`<html lang=..>`)

Closes #150.