### PR TITLE
Add timezone offset normalisation

### DIFF
--- a/mf2py/datetime_helpers.py
+++ b/mf2py/datetime_helpers.py
@@ -58,5 +58,5 @@ def normalize_datetime(dtstr, match=None):
 
         tzstr = match.group("tz")
         if tzstr:
-            dtstr += tzstr
+            dtstr += tzstr.replace(":", "")
     return dtstr

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -136,11 +136,11 @@ def test_plain_child_microformat():
 
 def test_datetime_parsing():
     result = parse_fixture("datetimes.html")
-    assert result["items"][0]["properties"]["start"][0] == "2014-01-01T12:00:00+00:00"
-    assert result["items"][0]["properties"]["end"][0] == "3014-01-01T18:00:00+00:00"
+    assert result["items"][0]["properties"]["start"][0] == "2014-01-01T12:00:00+0000"
+    assert result["items"][0]["properties"]["end"][0] == "3014-01-01T18:00:00+0000"
     assert result["items"][0]["properties"]["duration"][0] == "P1000Y"
-    assert result["items"][0]["properties"]["updated"][0] == "2011-08-26T00:01:21+00:00"
-    assert result["items"][0]["properties"]["updated"][1] == "2011-08-26T00:01:21+00:00"
+    assert result["items"][0]["properties"]["updated"][0] == "2011-08-26T00:01:21+0000"
+    assert result["items"][0]["properties"]["updated"][1] == "2011-08-26T00:01:21+0000"
 
 
 def test_datetime_vcp_parsing():
@@ -149,19 +149,19 @@ def test_datetime_vcp_parsing():
     assert result["items"][1]["properties"]["published"][0] == "3014-01-01 01:21Z"
     assert result["items"][2]["properties"]["updated"][0] == "2014-03-11 09:55"
     assert result["items"][3]["properties"]["published"][0] == "2014-01-30 15:28"
-    assert result["items"][4]["properties"]["published"][0] == "9999-01-14T11:52+08:00"
-    assert result["items"][5]["properties"]["published"][0] == "2014-06-01 12:30-06:00"
-    assert result["items"][8]["properties"]["start"][0] == "2014-06-01 12:30-06:00"
-    assert result["items"][9]["properties"]["start"][0] == "2014-06-01 12:30-06:00"
-    assert result["items"][10]["properties"]["start"][0] == "2014-06-01 00:30-06:00"
+    assert result["items"][4]["properties"]["published"][0] == "9999-01-14T11:52+0800"
+    assert result["items"][5]["properties"]["published"][0] == "2014-06-01 12:30-0600"
+    assert result["items"][8]["properties"]["start"][0] == "2014-06-01 12:30-0600"
+    assert result["items"][9]["properties"]["start"][0] == "2014-06-01 12:30-0600"
+    assert result["items"][10]["properties"]["start"][0] == "2014-06-01 00:30-0600"
     assert result["items"][10]["properties"]["end"][0] == "2014-06-01 12:15"
-    assert result["items"][10]["properties"]["start"][1] == "2014-06-01 00:30-06:00"
+    assert result["items"][10]["properties"]["start"][1] == "2014-06-01 00:30-0600"
     assert result["items"][10]["properties"]["end"][1] == "2014-06-01 12:15"
-    assert result["items"][11]["properties"]["start"][0] == "2016-03-02 00:30-06:00"
-    assert result["items"][12]["properties"]["start"][0] == "2014-06-01 12:30-6:00"
-    assert result["items"][13]["properties"]["start"][0] == "2014-06-01 12:30+6:00"
+    assert result["items"][11]["properties"]["start"][0] == "2016-03-02 00:30-0600"
+    assert result["items"][12]["properties"]["start"][0] == "2014-06-01 12:30-600"
+    assert result["items"][13]["properties"]["start"][0] == "2014-06-01 12:30+600"
     assert result["items"][14]["properties"]["start"][0] == "2014-06-01 12:30Z"
-    assert result["items"][15]["properties"]["start"][0] == "2014-06-01 12:30-6:00"
+    assert result["items"][15]["properties"]["start"][0] == "2014-06-01 12:30-600"
 
 
 def test_dt_end_implied_date():
@@ -175,8 +175,8 @@ def test_dt_end_implied_date():
     assert event_wo_tz["properties"]["end"][0] == "2014-05-21 19:30"
 
     event_w_tz = result["items"][7]
-    assert event_w_tz["properties"]["start"][0] == "2014-06-01 12:30-06:00"
-    assert event_w_tz["properties"]["end"][0] == "2014-06-01 19:30-06:00"
+    assert event_w_tz["properties"]["start"][0] == "2014-06-01 12:30-0600"
+    assert event_w_tz["properties"]["end"][0] == "2014-06-01 19:30-0600"
 
 
 def test_embedded_parsing():


### PR DESCRIPTION
Applies to VCP and standard dt- objects.

Closes #176 and spills into https://github.com/microformats/microformats2-parsing/issues/12. We are already normalizing all datetime objects so it would be awkward to implement for VCP and not dt- objects.