### PR TITLE
Fix whitespace in plaintext conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2.0 - unreleased
 - make relative URLs in e-* properties absolute (#201)
+- fix whitespace in plaintext conversion (#207)
 
 ## 1.1.3 - 2023-06-28
 - reduce instances where photo is implied (#135)

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -119,8 +119,7 @@ def get_textContent(el, replace_img=False, img_to_src=True, base_url=""):
                 items.extend(child_items)
 
             if el.name == "p":
-                items = [P_BREAK_BEFORE] + items
-                items.append(P_BREAK_AFTER)
+                items = [P_BREAK_BEFORE] + items + [P_BREAK_AFTER, "\n"]
 
         return items
 

--- a/test/examples/plaintext_img_whitespace.html
+++ b/test/examples/plaintext_img_whitespace.html
@@ -1,0 +1,19 @@
+<base href="https://example.com">
+
+<div class="h-entry">
+  <div class="e-content">
+    <img src="/photo.jpg" alt="selfie">At some tourist spot
+  </div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content">
+    <img src="/photo.jpg" alt="">At another tourist spot
+  </div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content">
+    <img src="/photo.jpg">At yet another tourist spot
+  </div>
+</div>

--- a/test/examples/plaintext_p_whitespace.html
+++ b/test/examples/plaintext_p_whitespace.html
@@ -1,0 +1,17 @@
+<div class="h-entry">
+  <div class="e-content">
+    <p>foo</p><img src="pic.png" alt="bar">baz
+  </div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content">
+    <p>foo</p>bar baz
+  </div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content">
+    foo bar<p>baz</p>
+  </div>
+</div>

--- a/test/examples/value_name_whitespace.html
+++ b/test/examples/value_name_whitespace.html
@@ -23,10 +23,6 @@ World</p></div>
 </div>
 
 <div class="h-entry">
-  <div class="e-content p-name"><p>Hello</p><p>World</p></div>
-</div>
-
-<div class="h-entry">
   <div class="e-content p-name">Hello<br>
     World</div>
 </div>
@@ -36,11 +32,7 @@ World</p></div>
 </div>
 
 <div class="h-entry">
-  <div class="e-content p-name">
-    <p>One</p>
-    <p>Two</p>
-    <p>Three</p>
-  </div>
+  <div class="e-content p-name"><p>Hello</p><p>World</p></div>
 </div>
 
 <div class="h-entry">
@@ -48,6 +40,14 @@ World</p></div>
     <pre>One
 Two
 Three</pre>
+  </div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content p-name">
+    <p>One</p>
+    <p>Two</p>
+    <p>Three</p>
   </div>
 </div>
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -187,7 +187,7 @@ def test_embedded_parsing():
     )
     assert (
         result["items"][0]["properties"]["content"][0]["value"]
-        == "Blah blah blah blah blah.\nBlah.\nBlah blah blah."
+        == "Blah blah blah blah blah.\n\nBlah.\n\nBlah blah blah."
     )
 
 
@@ -605,15 +605,20 @@ def test_value_name_whitespace():
         assert result["items"][i]["properties"]["content"][0]["value"] == "Hello World"
         assert result["items"][i]["properties"]["name"][0] == "Hello World"
 
-    for i in range(3, 8):
+    for i in range(3, 7):
         assert result["items"][i]["properties"]["content"][0]["value"] == "Hello\nWorld"
         assert result["items"][i]["properties"]["name"][0] == "Hello\nWorld"
 
-    for i in range(8, 10):
-        assert (
-            result["items"][i]["properties"]["content"][0]["value"] == "One\nTwo\nThree"
-        )
-        assert result["items"][i]["properties"]["name"][0] == "One\nTwo\nThree"
+    assert result["items"][7]["properties"]["content"][0]["value"] == "Hello\n\nWorld"
+    assert result["items"][7]["properties"]["name"][0] == "Hello\n\nWorld"
+
+    assert result["items"][8]["properties"]["content"][0]["value"] == "One\nTwo\nThree"
+    assert result["items"][8]["properties"]["name"][0] == "One\nTwo\nThree"
+
+    assert (
+        result["items"][9]["properties"]["content"][0]["value"] == "One\n\nTwo\n\nThree"
+    )
+    assert result["items"][9]["properties"]["name"][0] == "One\n\nTwo\n\nThree"
 
     assert (
         result["items"][10]["properties"]["content"][0]["value"]
@@ -861,6 +866,13 @@ def test_whitespace_with_tags_inside_property():
     """
     result = parse_fixture("tag_whitespace_inside_p_value.html")
     assert result["items"][0]["properties"] == {"name": ["foo bar"]}
+
+
+def test_plaintext_img_whitespace():
+    result = parse_fixture("plaintext_p_whitespace.html")
+    assert result["items"][0]["properties"]["content"][0]["value"] == "foo\nbar baz"
+    assert result["items"][1]["properties"]["content"][0]["value"] == "foo\nbar baz"
+    assert result["items"][2]["properties"]["content"][0]["value"] == "foo bar\nbaz"
 
 
 def test_photo_with_alt():

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -875,6 +875,22 @@ def test_plaintext_p_whitespace():
     assert result["items"][2]["properties"]["content"][0]["value"] == "foo bar\nbaz"
 
 
+def test_plaintext_img_whitespace():
+    result = parse_fixture("plaintext_img_whitespace.html")
+    assert (
+        result["items"][0]["properties"]["content"][0]["value"]
+        == "selfie At some tourist spot"
+    )
+    assert (
+        result["items"][1]["properties"]["content"][0]["value"]
+        == "At another tourist spot"
+    )
+    assert (
+        result["items"][2]["properties"]["content"][0]["value"]
+        == "https://example.com/photo.jpg At yet another tourist spot"
+    )
+
+
 def test_photo_with_alt():
     """Confirm that alt text in img is parsed as a u-* property and implied photo"""
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -868,7 +868,7 @@ def test_whitespace_with_tags_inside_property():
     assert result["items"][0]["properties"] == {"name": ["foo bar"]}
 
 
-def test_plaintext_img_whitespace():
+def test_plaintext_p_whitespace():
     result = parse_fixture("plaintext_p_whitespace.html")
     assert result["items"][0]["properties"]["content"][0]["value"] == "foo\nbar baz"
     assert result["items"][1]["properties"]["content"][0]["value"] == "foo\nbar baz"


### PR DESCRIPTION
A newline is added after paragraphs during plaintext conversion.

Closes #202.