### PR TITLE
Add srcset support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## 2.0 - unreleased
 - make relative URLs in e-* properties absolute (#201)
 - fix whitespace in plaintext conversion (#207)
+- add srcset support (#209)
 
 ## 1.1.3 - 2023-06-28
 - reduce instances where photo is implied (#135)

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -43,7 +43,9 @@ def parse_srcset(srcset, base_url):
     """Return a dictionary of sources found in srcset."""
     sources = {}
     for url, descriptor in re.findall(
-        r"(\S+)\s?([\d.]+[xw])?[,\s]?", srcset, re.MULTILINE
+        r"(\S+)\s*([\d.]+[xw])?\s*,?\s*",
+        srcset,
+        re.MULTILINE,
     ):
         if not descriptor:
             descriptor = "1x"

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -62,9 +62,9 @@ def get_img(img, base_url):
     src = try_urljoin(base_url, src)
     alt = get_attr(img, "alt", check_name="img")
     srcset = get_attr(img, "srcset", check_name="img")
-    if alt or srcset:
+    if alt is not None or srcset:
         prop_value = {"value": src}
-        if alt:
+        if alt is not None:
             prop_value["alt"] = alt
         if srcset:
             prop_value["srcset"] = parse_srcset(srcset, base_url)

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -43,14 +43,12 @@ def parse_srcset(srcset, base_url):
     """Return a dictionary of sources found in srcset."""
     sources = {}
     for url, descriptor in re.findall(
-        r"(\S+)(\s[\d.]+[xw])?,?\s?", srcset, re.MULTILINE
+        r"(\S+)\s?([\d.]+[xw])?[,\s]?", srcset, re.MULTILINE
     ):
-        url = url.strip(",")
-        descriptor = descriptor.strip()
         if not descriptor:
             descriptor = "1x"
         if descriptor not in sources:
-            sources[descriptor] = try_urljoin(base_url, url)
+            sources[descriptor] = try_urljoin(base_url, url.strip(","))
     return sources
 
 

--- a/mf2py/implied_properties.py
+++ b/mf2py/implied_properties.py
@@ -1,11 +1,5 @@
 from . import mf2_classes
-from .dom_helpers import (
-    get_attr,
-    get_children,
-    get_img_src_alt,
-    get_textContent,
-    try_urljoin,
-)
+from .dom_helpers import get_attr, get_children, get_img, get_textContent, try_urljoin
 
 
 def name(el, base_url=""):
@@ -111,7 +105,7 @@ def photo(el, base_url=""):
         return prop_value
 
     # if element is an img use source if exists
-    if prop_value := get_img_src_alt(el, base_url):
+    if prop_value := get_img(el, base_url):
         return resolve_relative_url(prop_value)
 
     # if element is an object use data if exists
@@ -136,7 +130,7 @@ def photo(el, base_url=""):
     # if a possible child was found parse
     if poss_child is not None:
         # img get src
-        if prop_value := get_img_src_alt(poss_child, base_url):
+        if prop_value := get_img(poss_child, base_url):
             return resolve_relative_url(prop_value)
 
         # object get data

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -4,7 +4,7 @@ import re
 
 from . import value_class_pattern
 from .datetime_helpers import DATETIME_RE, TIME_RE, normalize_datetime
-from .dom_helpers import get_attr, get_img_src_alt, get_textContent, try_urljoin
+from .dom_helpers import get_attr, get_img, get_textContent, try_urljoin
 
 
 def text(el, base_url=""):
@@ -31,7 +31,7 @@ def url(el, base_url=""):
 
     prop_value = get_attr(el, "href", check_name=("a", "area", "link"))
     if prop_value is None:
-        prop_value = get_img_src_alt(el, base_url)
+        prop_value = get_img(el, base_url)
         if prop_value is not None:
             return prop_value
     if prop_value is None:

--- a/test/examples/img_with_srcset.html
+++ b/test/examples/img_with_srcset.html
@@ -60,3 +60,18 @@
        src="elva-fairy-320w.jpg"
        alt="Elva dressed as a fairy">
 </div>
+
+<div class="h-entry">
+  <img class="u-photo"
+       srcset="
+           elva-fairy,320w.jpg,
+               elva-fairy,480w.jpg
+       1.5x,
+               elva-fairy,640w.jpg 2x   ,
+
+               elva-fairy,1.5w.jpg     1.5x     ,
+               elva-fairy,2w.jpg 2x
+       "
+       src="elva-fairy-320w.jpg"
+       alt="Elva dressed as a fairy">
+</div>

--- a/test/examples/img_with_srcset.html
+++ b/test/examples/img_with_srcset.html
@@ -1,0 +1,48 @@
+<div class="h-entry">
+  <img class="u-photo"
+       srcset="elva-fairy-480w.jpg 480w,
+               elva-fairy-800w.jpg 800w"
+       sizes="(max-width: 600px) 480px,
+              800px"
+       src="elva-fairy-800w.jpg"
+       alt="Elva dressed as a fairy">
+</div>
+
+<div class="h-entry">
+  <img class="u-photo"
+       srcset="elva-fairy-320w.jpg,
+               elva-fairy-480w.jpg 1.5x,
+               elva-fairy-640w.jpg 2x,
+               elva-fairy-1.5w.jpg 1.5x,
+               elva-fairy-2w.jpg 2x"
+       src="elva-fairy-320w.jpg"
+       alt="Elva dressed as a fairy">
+</div>
+
+<div class="h-entry">
+  <img class="u-photo"
+       srcset="elva-fairy,320w.jpg, elva-fairy,480w.jpg 1.5x"
+       src="elva-fairy-320w.jpg"
+       alt="Elva dressed as a fairy">
+</div>
+
+<div class="h-entry">
+  <img class="u-photo"
+       srcset="elva-fairy,320w.jpg ,elva-fairy,480w.jpg 1.5x"
+       src="elva-fairy-320w.jpg"
+       alt="Elva dressed as a fairy">
+</div>
+
+<div class="h-entry">
+  <img class="u-photo"
+       srcset="elva-fairy,320w.jpg 1x,elva-fairy,480w.jpg 1.5x"
+       src="elva-fairy-320w.jpg"
+       alt="Elva dressed as a fairy">
+</div>
+
+<div class="h-entry">
+  <img class="u-photo"
+       srcset="elva-fairy,320w.jpg"
+       src="elva-fairy-320w.jpg"
+       alt="Elva dressed as a fairy">
+</div>

--- a/test/examples/img_with_srcset.html
+++ b/test/examples/img_with_srcset.html
@@ -42,6 +42,20 @@
 
 <div class="h-entry">
   <img class="u-photo"
+       srcset="elva-fairy,320w.jpg 1x ,elva-fairy,480w.jpg 1.5x"
+       src="elva-fairy-320w.jpg"
+       alt="Elva dressed as a fairy">
+</div>
+
+<div class="h-entry">
+  <img class="u-photo"
+       srcset="elva-fairy,320w.jpg 1x , elva-fairy,480w.jpg 1.5x"
+       src="elva-fairy-320w.jpg"
+       alt="Elva dressed as a fairy">
+</div>
+
+<div class="h-entry">
+  <img class="u-photo"
        srcset="elva-fairy,320w.jpg"
        src="elva-fairy-320w.jpg"
        alt="Elva dressed as a fairy">

--- a/test/examples/img_with_srcset_with_base.html
+++ b/test/examples/img_with_srcset_with_base.html
@@ -1,0 +1,11 @@
+<base href="https://example.com">
+
+<div class="h-entry">
+  <img class="u-photo"
+       srcset="elva-fairy-480w.jpg 480w,
+               elva-fairy-800w.jpg 800w"
+       sizes="(max-width: 600px) 480px,
+              800px"
+       src="elva-fairy-800w.jpg"
+       alt="Elva dressed as a fairy">
+</div>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -502,10 +502,9 @@ def test_implied_nested_photo():
     result = parse_fixture(
         "implied_properties/implied_properties.html", url="http://bar.org"
     )
-    assert result["items"][2]["properties"]["photo"][0] == {
-        "alt": "",
-        "value": "http://tommorris.org/photo.png",
-    }
+    assert (
+        result["items"][2]["properties"]["photo"][0] == "http://tommorris.org/photo.png"
+    )
     assert (
         result["items"][3]["properties"]["photo"][0] == "http://tommorris.org/photo.png"
     )
@@ -544,7 +543,7 @@ def test_implied_name_empty_alt():
         "properties": {
             "name": ["@kylewmahan"],
             "url": ["https://twitter.com/kylewmahan"],
-            "photo": [{"alt": "", "value": "https://example.org/test.jpg"}],
+            "photo": ["https://example.org/test.jpg"],
         },
     } == hcard
 
@@ -883,13 +882,7 @@ def test_photo_with_alt():
     assert "/photo.jpg" == exp_result["items"][1]["properties"]["url"][0]["value"]
     assert "alt text" == exp_result["items"][1]["properties"]["url"][0]["alt"]
 
-    assert {"alt": "", "value": "/photo.jpg"} == result["items"][2]["properties"][
-        "in-reply-to"
-    ][0]
-    assert (
-        "/photo.jpg" == exp_result["items"][2]["properties"]["in-reply-to"][0]["value"]
-    )
-    assert "" == exp_result["items"][2]["properties"]["in-reply-to"][0]["alt"]
+    assert "/photo.jpg" == result["items"][2]["properties"]["in-reply-to"][0]
 
     # img with u-* and h-* example
     assert "h-cite" in result["items"][3]["properties"]["in-reply-to"][0]["type"]
@@ -938,29 +931,55 @@ def test_photo_with_alt():
     assert "alt text" == exp_result["items"][4]["properties"]["in-reply-to"][0]["alt"]
 
     assert "h-cite" in result["items"][5]["properties"]["in-reply-to"][0]["type"]
-    assert {"alt": "", "value": "/photo.jpg"} == result["items"][5]["properties"][
-        "in-reply-to"
-    ][0]["properties"]["photo"][0]
+    assert (
+        "/photo.jpg"
+        == result["items"][5]["properties"]["in-reply-to"][0]["properties"]["photo"][0]
+    )
     assert "/photo.jpg" == result["items"][5]["properties"]["in-reply-to"][0]["value"]
-    assert "alt" in result["items"][5]["properties"]["in-reply-to"][0]
 
     assert "h-cite" in exp_result["items"][5]["properties"]["in-reply-to"][0]["type"]
     assert (
         "/photo.jpg"
         == exp_result["items"][5]["properties"]["in-reply-to"][0]["properties"][
             "photo"
-        ][0]["value"]
+        ][0]
     )
     assert (
         "/photo.jpg" == exp_result["items"][5]["properties"]["in-reply-to"][0]["value"]
     )
+
+
+def test_photo_with_srcset():
+    result = parse_fixture("img_with_srcset.html")
+
+    assert result["items"][0]["properties"]["photo"][0]["srcset"] == {
+        "480w": "elva-fairy-480w.jpg",
+        "800w": "elva-fairy-800w.jpg",
+    }
+    assert result["items"][1]["properties"]["photo"][0]["srcset"] == {
+        "1x": "elva-fairy-320w.jpg",
+        "1.5x": "elva-fairy-480w.jpg",
+        "2x": "elva-fairy-640w.jpg",
+    }
     assert (
-        ""
-        == exp_result["items"][5]["properties"]["in-reply-to"][0]["properties"][
-            "photo"
-        ][0]["alt"]
+        result["items"][1]["properties"]["photo"][0]["srcset"]["2x"]
+        != "elva-fairy-2w.jpg"
     )
-    assert "" == exp_result["items"][5]["properties"]["in-reply-to"][0]["alt"]
+    for i in range(2, 5):
+        assert result["items"][i]["properties"]["photo"][0]["srcset"] == {
+            "1x": "elva-fairy,320w.jpg",
+            "1.5x": "elva-fairy,480w.jpg",
+        }
+    assert result["items"][5]["properties"]["photo"][0]["srcset"] == {
+        "1x": "elva-fairy,320w.jpg",
+    }
+
+    result = parse_fixture("img_with_srcset_with_base.html")
+
+    assert result["items"][0]["properties"]["photo"][0]["srcset"] == {
+        "480w": "https://example.com/elva-fairy-480w.jpg",
+        "800w": "https://example.com/elva-fairy-800w.jpg",
+    }
 
 
 def test_parse_id():

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -886,9 +886,10 @@ def test_photo_with_alt():
     assert {"alt": "", "value": "/photo.jpg"} == result["items"][2]["properties"][
         "in-reply-to"
     ][0]
-    assert {"alt": "", "value": "/photo.jpg"} == result["items"][2]["properties"][
-        "in-reply-to"
-    ][0]
+    assert (
+        "/photo.jpg" == exp_result["items"][2]["properties"]["in-reply-to"][0]["value"]
+    )
+    assert "" == exp_result["items"][2]["properties"]["in-reply-to"][0]["alt"]
 
     # img with u-* and h-* example
     assert "h-cite" in result["items"][3]["properties"]["in-reply-to"][0]["type"]
@@ -940,18 +941,26 @@ def test_photo_with_alt():
     assert {"alt": "", "value": "/photo.jpg"} == result["items"][5]["properties"][
         "in-reply-to"
     ][0]["properties"]["photo"][0]
-    assert {"alt": "", "value": "/photo.jpg"} == result["items"][5]["properties"][
-        "in-reply-to"
-    ][0]["properties"]["photo"][0]
     assert "/photo.jpg" == result["items"][5]["properties"]["in-reply-to"][0]["value"]
+    assert "alt" in result["items"][5]["properties"]["in-reply-to"][0]
 
     assert "h-cite" in exp_result["items"][5]["properties"]["in-reply-to"][0]["type"]
-    assert {"alt": "", "value": "/photo.jpg"} == exp_result["items"][5]["properties"][
-        "in-reply-to"
-    ][0]["properties"]["photo"][0]
+    assert (
+        "/photo.jpg"
+        == exp_result["items"][5]["properties"]["in-reply-to"][0]["properties"][
+            "photo"
+        ][0]["value"]
+    )
     assert (
         "/photo.jpg" == exp_result["items"][5]["properties"]["in-reply-to"][0]["value"]
     )
+    assert (
+        ""
+        == exp_result["items"][5]["properties"]["in-reply-to"][0]["properties"][
+            "photo"
+        ][0]["alt"]
+    )
+    assert "" == exp_result["items"][5]["properties"]["in-reply-to"][0]["alt"]
 
 
 def test_photo_with_srcset():

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -987,6 +987,11 @@ def test_photo_with_srcset():
     assert result["items"][7]["properties"]["photo"][0]["srcset"] == {
         "1x": "elva-fairy,320w.jpg",
     }
+    assert result["items"][8]["properties"]["photo"][0]["srcset"] == {
+        "1x": "elva-fairy,320w.jpg",
+        "1.5x": "elva-fairy,480w.jpg",
+        "2x": "elva-fairy,640w.jpg",
+    }
 
     result = parse_fixture("img_with_srcset_with_base.html")
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -979,12 +979,12 @@ def test_photo_with_srcset():
         result["items"][1]["properties"]["photo"][0]["srcset"]["2x"]
         != "elva-fairy-2w.jpg"
     )
-    for i in range(2, 5):
+    for i in range(2, 7):
         assert result["items"][i]["properties"]["photo"][0]["srcset"] == {
             "1x": "elva-fairy,320w.jpg",
             "1.5x": "elva-fairy,480w.jpg",
         }
-    assert result["items"][5]["properties"]["photo"][0]["srcset"] == {
+    assert result["items"][7]["properties"]["photo"][0]["srcset"] == {
         "1x": "elva-fairy,320w.jpg",
     }
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -502,9 +502,10 @@ def test_implied_nested_photo():
     result = parse_fixture(
         "implied_properties/implied_properties.html", url="http://bar.org"
     )
-    assert (
-        result["items"][2]["properties"]["photo"][0] == "http://tommorris.org/photo.png"
-    )
+    assert result["items"][2]["properties"]["photo"][0] == {
+        "alt": "",
+        "value": "http://tommorris.org/photo.png",
+    }
     assert (
         result["items"][3]["properties"]["photo"][0] == "http://tommorris.org/photo.png"
     )
@@ -543,7 +544,7 @@ def test_implied_name_empty_alt():
         "properties": {
             "name": ["@kylewmahan"],
             "url": ["https://twitter.com/kylewmahan"],
-            "photo": ["https://example.org/test.jpg"],
+            "photo": [{"alt": "", "value": "https://example.org/test.jpg"}],
         },
     } == hcard
 
@@ -882,7 +883,12 @@ def test_photo_with_alt():
     assert "/photo.jpg" == exp_result["items"][1]["properties"]["url"][0]["value"]
     assert "alt text" == exp_result["items"][1]["properties"]["url"][0]["alt"]
 
-    assert "/photo.jpg" == result["items"][2]["properties"]["in-reply-to"][0]
+    assert {"alt": "", "value": "/photo.jpg"} == result["items"][2]["properties"][
+        "in-reply-to"
+    ][0]
+    assert {"alt": "", "value": "/photo.jpg"} == result["items"][2]["properties"][
+        "in-reply-to"
+    ][0]
 
     # img with u-* and h-* example
     assert "h-cite" in result["items"][3]["properties"]["in-reply-to"][0]["type"]
@@ -931,19 +937,18 @@ def test_photo_with_alt():
     assert "alt text" == exp_result["items"][4]["properties"]["in-reply-to"][0]["alt"]
 
     assert "h-cite" in result["items"][5]["properties"]["in-reply-to"][0]["type"]
-    assert (
-        "/photo.jpg"
-        == result["items"][5]["properties"]["in-reply-to"][0]["properties"]["photo"][0]
-    )
+    assert {"alt": "", "value": "/photo.jpg"} == result["items"][5]["properties"][
+        "in-reply-to"
+    ][0]["properties"]["photo"][0]
+    assert {"alt": "", "value": "/photo.jpg"} == result["items"][5]["properties"][
+        "in-reply-to"
+    ][0]["properties"]["photo"][0]
     assert "/photo.jpg" == result["items"][5]["properties"]["in-reply-to"][0]["value"]
 
     assert "h-cite" in exp_result["items"][5]["properties"]["in-reply-to"][0]["type"]
-    assert (
-        "/photo.jpg"
-        == exp_result["items"][5]["properties"]["in-reply-to"][0]["properties"][
-            "photo"
-        ][0]
-    )
+    assert {"alt": "", "value": "/photo.jpg"} == exp_result["items"][5]["properties"][
+        "in-reply-to"
+    ][0]["properties"]["photo"][0]
     assert (
         "/photo.jpg" == exp_result["items"][5]["properties"]["in-reply-to"][0]["value"]
     )


### PR DESCRIPTION
- a source without a descriptor defaults to `1x`
- sources with already seen descriptors are ignored
- URLs may contain a comma

Closes #169.