### PR TITLE
Add language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 - make relative URLs in e-* properties absolute (#201)
 - fix whitespace in plaintext conversion (#207)
 - add srcset support (#209)
+- add language support (#210)
 
 ## 1.1.3 - 2023-06-28
 - reduce instances where photo is implied (#135)

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -94,9 +94,16 @@ def datetime(el, default_date=None):
     )
 
 
-def embedded(el, base_url=""):
+def embedded(el, root_lang, document_lang, base_url=""):
     """Process e-* properties"""
-    return {
+    prop_value = {
         "html": el.decode_contents().strip(),  # secret bs4 method to get innerHTML
         "value": get_textContent(el, replace_img=True, base_url=base_url),
     }
+    if lang := el.attrs.get("lang"):
+        prop_value["lang"] = lang
+    elif root_lang:
+        prop_value["lang"] = root_lang
+    elif document_lang:
+        prop_value["lang"] = document_lang
+    return prop_value

--- a/test/examples/language.html
+++ b/test/examples/language.html
@@ -1,0 +1,15 @@
+<html lang="it">
+  <div class="h-card">
+    <h1 class="p-name">Romero</h1>
+  </div>
+  <div class="h-entry">
+    <h1 class="p-name">Un titolo italiano</h1>
+    <div class="e-content" lang="en">With an <em>english</em> summary</div>
+    <div class="e-content">Con un riassunto <em>italiano</em></div>
+  </div>
+  <div class="h-entry" lang="sv">
+    <h1 class="p-name">En svensk titel</h1>
+    <div class="e-content" lang="en">With an <em>english</em> summary</div>
+    <div class="e-content">Och <em>svensk</em> huvudtext</div>
+  </div>
+</html>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1040,3 +1040,14 @@ def test_all_u_cases():
         make_labelled_cmp("all_u_cases_" + str(i))(
             "http://example.com/test", result["items"][0]["properties"]["url"][i]
         )
+
+
+def test_language():
+    result = parse_fixture("language.html")
+    assert result["items"][0]["lang"] == "it"
+    assert result["items"][1]["lang"] == "it"
+    assert result["items"][1]["properties"]["content"][0]["lang"] == "en"
+    assert result["items"][1]["properties"]["content"][1]["lang"] == "it"
+    assert result["items"][2]["lang"] == "sv"
+    assert result["items"][2]["properties"]["content"][0]["lang"] == "en"
+    assert result["items"][2]["properties"]["content"][1]["lang"] == "sv"


### PR DESCRIPTION
Add language details to embedded properties and root microformats using the following order of specificity:

    embedded properties (class=e-* lang=..)
    root microformats (class=h-* lang=..)
    document root (<html lang=..>)

Closes #150.