### PR TITLE
Sanitize embedded properties according to HTML5 spec

### DIFF
--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -112,5 +112,5 @@ def embedded(el, base_url, root_lang, document_lang, expose_dom):
     if expose_dom:
         prop_value["dom"] = el
     else:
-        prop_value["html"] = el.decode_contents().strip()
+        prop_value["html"] = el.decode_contents(formatter="html5").strip()
     return prop_value

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -403,7 +403,7 @@ def test_relative_url_in_e():
 
     assert (
         '<p><a href="http://example.com/cat.html">Cat '
-        '<img src="http://example.com/cat.jpg"/></a></p>'
+        '<img src="http://example.com/cat.jpg"></a></p>'
     ) == result["items"][0]["properties"]["content"][0]["html"]
 
 


### PR DESCRIPTION
Closes #95.

The returned `"html"` of an embedded property is sanitized according to the HTML5 spec.

It doesn't retain the authored HTML as requested in the issue but it will prevent the addition of extraneous trailing solidi.