### PR TITLE
Skip implied name for nested backcompat `geo`

### DIFF
--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -241,8 +241,10 @@ class Parser(object):
             # if some properties not already found find in implied ways unless in backcompat mode
             if not backcompat_mode:
                 # stop implied name if any p-*, e-*, h-* is already found
-                if "name" not in properties and parsed_types_aggregation.isdisjoint(
-                    "peh"
+                if (
+                    "name" not in properties
+                    and parsed_types_aggregation.isdisjoint("peh")
+                    and "h-geo" not in el.attrs["class"]  # skip nested backcompat geo
                 ):
                     properties["name"] = [
                         implied_properties.name(el, self.__url__, self.filtered_roots)

--- a/test/examples/implied_properties/implied_nested_backcompat.html
+++ b/test/examples/implied_properties/implied_nested_backcompat.html
@@ -1,0 +1,4 @@
+<div class="vcard">
+  <div class="fn">John Doe</div>
+  <div>Location: <abbr class="geo" title="30.267991;-97.739568"><a class="u-url" href="https://brighton.co.uk">Brighton</a></abbr></div>
+</div>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -540,6 +540,25 @@ def test_implied_nested_photo_alt_name():
     assert result["items"][3]["properties"]["name"][0] == "Tom Morris"
 
 
+def test_implied_nested_backcompat():
+    result = parse_fixture("implied_properties/implied_nested_backcompat.html")
+    hcard = result["items"][0]
+
+    assert {
+        "type": ["h-card"],
+        "properties": {
+            "name": ["John Doe"],
+            "geo": [
+                {
+                    "type": ["h-geo"],
+                    "properties": {"url": ["https://brighton.co.uk"]},
+                    "value": "30.267991;-97.739568",
+                }
+            ],
+        },
+    } == hcard
+
+
 def test_implied_image():
     result = parse_fixture("implied_properties/implied_properties.html")
     assert result["items"][4]["properties"]["photo"][0] == {


### PR DESCRIPTION
Technically closes #127.

Is this a general problem affecting more than just `geo`?